### PR TITLE
fix: kana switching bugs, IME arrow wrap, and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,95 @@
-﻿# Kana Site
+# kana-site
 
-[![Deploy Pages](https://github.com/ringxworld/kana-site/actions/workflows/deploy.yml/badge.svg)](https://github.com/ringxworld/kana-site/actions/workflows/deploy.yml)
-[![CI](https://github.com/ringxworld/kana-site/actions/workflows/ci.yml/badge.svg)](https://github.com/ringxworld/kana-site/actions/workflows/ci.yml)
+[![Quality Gates](https://github.com/shikarii/kana-site/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/shikarii/kana-site/actions/workflows/quality-gates.yml)
+[![Deploy Pages](https://github.com/shikarii/kana-site/actions/workflows/deploy.yml/badge.svg)](https://github.com/shikarii/kana-site/actions/workflows/deploy.yml)
 
-A simple, self-contained web app for practicing Japanese typing and conversions.
-It takes romaji input and converts it to hiragana, katakana, or kanji suggestions — just like an IME, but in your browser.
+Browser-based Japanese IME practice tool. Type romaji and get real-time hiragana/katakana
+conversion, kanji suggestions via SKK dictionary, furigana rendering, and text-to-speech.
 
-Live links:
-- **App**: https://ringxworld.github.io/kana-site/
-- **Reader**: https://ringxworld.github.io/kana-site/#/reader
+Live site: **https://shikarii.github.io/kana-site/**
 
 ---
 
 ## Features
 
-- **Romaji → Kana conversion**
-  Type naturally (e.g. `nihongo`) and it instantly converts to `にほんご` or `ニホンゴ`.
-
-- **Kanji suggestions**
-  Shows matching words like `日本語` for `にほんご`.
-  You can toggle or accept suggestions just like a normal IME.
-
-- **Text-to-Speech (TTS)**
-  Hear your text spoken with a Japanese voice — great for quick pronunciation checks.
-
-- **Furigana reader**
-  Paste paired JP/EN lines and render furigana with per-sentence English reveal.
-
-- **Single-page app**
-  Lightweight, client-only app built with React + Vite.
+| Feature           | Description                                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Romaji → Kana     | Type `nihongo` → `にほんご` or `ニホンゴ`. Switches between hiragana and katakana at any time, including re-converting existing text. |
+| Kanji suggestions | SKK dictionary lookup via a background web worker. Arrow keys navigate suggestions; Enter commits; Escape dismisses.                  |
+| Text-to-Speech    | Japanese voice playback via Web Speech API.                                                                                           |
+| Furigana Reader   | Paste paired JP/EN lines; renders inline furigana with per-sentence English reveal.                                                   |
 
 ---
 
-## Usage
+## Getting started
 
-1. Type in romaji (e.g. `nihongo`).
-2. The text area updates in real time.
-3. Toggle between:
-   - Hiragana
-   - Katakana
-   - None
-4. Kanji suggestions appear for trailing hiragana.
-5. Optionally use the **Speak** button to hear the text.
+```bash
+git clone https://github.com/shikarii/kana-site
+cd kana-site
+npm install
+npm run setup          # sync kuromoji/ipadic vendor assets and fetch SKK dictionary
+bash scripts/setup_hooks.sh   # install git hooks (one-time)
+npm run dev            # start Vite dev server at http://localhost:5173
+```
 
 ---
 
-## Deployment (GitHub Pages)
+## Architecture
 
-This repo uses a GitHub Actions workflow that builds and deploys the site to GitHub Pages.
+```
+src/
+  lib/       pure logic — kana conversion, furigana parser, IME glue, TTS hook
+  pages/     route-level components — Romaji.tsx, Reader.tsx
+  components reusable UI primitives
+  types/     shared TypeScript interfaces
+public/
+  js/        ime-worker.js  (SKK + kuromoji web worker)
+  dict/      SKK-JISYO.L    (fetched by npm run setup)
+  vendor/    kuromoji + ipadic (synced by npm run setup)
+```
 
-Recommended Pages settings:
-- Source: **GitHub Actions**
+Import rules enforced by `AGENTS.md`:
 
-Notes:
-- Do not commit `dist/` to `main`.
-- The workflow publishes `dist/` automatically.
+- `lib/` must not import from `components/`, `pages/`, or `styles/`
+- `components/` must not import from `pages/`
 
-Manual build:
-- `npm run build`
+---
+
+## Development commands
+
+```bash
+npm run dev            # Vite dev server
+npm run test           # Vitest in watch mode
+npm run test:run       # run tests once
+npm run typecheck      # tsc --noEmit
+npm run lint:check     # ESLint
+npm run format         # Prettier
+npm run build          # production build → dist/
+```
+
+---
+
+## Quality gates
+
+Pre-commit and pre-push hooks enforce quality automatically after `bash scripts/setup_hooks.sh`.
+
+| Gate                              | Command                          | When                   |
+| --------------------------------- | -------------------------------- | ---------------------- |
+| Fast (format + lint + typecheck)  | `bash docker/scripts/ci_part.sh` | every commit           |
+| Full (all checks + tests + build) | `bash docker/scripts/ci_full.sh` | every push / before PR |
+
+A self-hosted GitHub Actions runner executes the same gates on every PR. See `AGENTS.md` for
+Docker runner setup instructions.
+
+---
+
+## Deployment
+
+GitHub Actions deploys to GitHub Pages automatically on push to `main`. The `dist/` directory
+is never committed directly.
+
+---
+
+## Contributing
+
+See `CONTRIBUTING.md` for setup steps, branch rules, and PR requirements.

--- a/src/lib/imeGlue.ts
+++ b/src/lib/imeGlue.ts
@@ -141,13 +141,13 @@ export function initIme({
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       if (currentList.length) {
-        currentIndex = Math.min(currentIndex + 1, currentList.length - 1);
+        currentIndex = (currentIndex + 1) % currentList.length;
         updateHighlight();
       }
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       if (currentList.length) {
-        currentIndex = Math.max(currentIndex - 1, 0);
+        currentIndex = (currentIndex - 1 + currentList.length) % currentList.length;
         updateHighlight();
       }
     } else if (e.key === 'Enter') {

--- a/src/lib/kana.test.ts
+++ b/src/lib/kana.test.ts
@@ -1,16 +1,149 @@
-﻿import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { convertKana } from './kana';
 
-describe('convertKana', () => {
-  it('converts romaji to hiragana by default', () => {
+// ---------------------------------------------------------------------------
+// Hiragana mode
+// ---------------------------------------------------------------------------
+describe('convertKana – hiragana mode', () => {
+  it('converts basic romaji', () => {
     expect(convertKana('nihongo')).toBe('にほんご');
   });
 
-  it('converts romaji to katakana', () => {
+  it('defaults to hiragana when no mode supplied', () => {
+    expect(convertKana('ka')).toBe('か');
+  });
+
+  it('double consonant produces small っ', () => {
+    expect(convertKana('katta')).toBe('かった');
+    expect(convertKana('zasshi')).toBe('ざっし');
+  });
+
+  it('n before non-vowel or at string boundary becomes ん', () => {
+    // wanakana converts every standalone n-before-n to ん
+    expect(convertKana('nihon')).toBe('にほん');
+    expect(convertKana('nani')).toBe('なに');
+  });
+
+  it('n before non-vowel becomes ん', () => {
+    expect(convertKana('nka')).toBe('んか');
+    expect(convertKana('tanki')).toBe('たんき');
+  });
+
+  it('digraphs – sha / chi / tsu', () => {
+    expect(convertKana('sha')).toBe('しゃ');
+    expect(convertKana('chi')).toBe('ち');
+    expect(convertKana('tsu')).toBe('つ');
+  });
+
+  it('digraphs – kyo / myo / ryu', () => {
+    expect(convertKana('kyo')).toBe('きょ');
+    expect(convertKana('myo')).toBe('みょ');
+    expect(convertKana('ryu')).toBe('りゅ');
+  });
+
+  it('passes through already-hiragana unchanged', () => {
+    expect(convertKana('にほんご', { mode: 'hiragana' })).toBe('にほんご');
+  });
+
+  it('converts katakana to hiragana', () => {
+    expect(convertKana('ニホンゴ', { mode: 'hiragana' })).toBe('にほんご');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(convertKana('')).toBe('');
+  });
+
+  it('normalises full-width ASCII via NFKC before converting', () => {
+    // full-width 'ａ' (U+FF41) normalises to 'a' → 'あ'
+    expect(convertKana('\uff41')).toBe('あ');
+  });
+
+  it('leaves unconvertible latin characters unchanged', () => {
+    // lone consonant at end stays as-is
+    const result = convertKana('k');
+    expect(result).toBe('k');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Katakana mode
+// ---------------------------------------------------------------------------
+describe('convertKana – katakana mode', () => {
+  it('converts basic romaji to katakana', () => {
     expect(convertKana('katakana', { mode: 'katakana' })).toBe('カタカナ');
   });
 
-  it('returns original text when mode is none', () => {
+  it('double consonant produces small ッ', () => {
+    expect(convertKana('katta', { mode: 'katakana' })).toBe('カッタ');
+  });
+
+  it('nn produces ン', () => {
+    expect(convertKana('nihon', { mode: 'katakana' })).toBe('ニホン');
+  });
+
+  it('converts hiragana to katakana', () => {
+    expect(convertKana('にほんご', { mode: 'katakana' })).toBe('ニホンゴ');
+  });
+
+  it('passes through already-katakana unchanged', () => {
+    expect(convertKana('ニホンゴ', { mode: 'katakana' })).toBe('ニホンゴ');
+  });
+
+  it('applies long vowel substitution for bare vowel sequences', () => {
+    // bare "ou" → オウ → applyKatakanaLongVowels → オー
+    expect(convertKana('ou', { mode: 'katakana' })).toBe('オー');
+    // consonant+ou stays as-is (コウ, not コー — function only sees bare vowel pairs)
+    expect(convertKana('ko', { mode: 'katakana' })).toBe('コ');
+  });
+
+  it('digraphs – sha / chi / kyo', () => {
+    expect(convertKana('sha', { mode: 'katakana' })).toBe('シャ');
+    expect(convertKana('chi', { mode: 'katakana' })).toBe('チ');
+    expect(convertKana('kyo', { mode: 'katakana' })).toBe('キョ');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(convertKana('', { mode: 'katakana' })).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mode switching round-trips
+// ---------------------------------------------------------------------------
+describe('convertKana – mode switching', () => {
+  it('hiragana → katakana round-trip', () => {
+    const hira = convertKana('nihongo', { mode: 'hiragana' });
+    expect(hira).toBe('にほんご');
+    const kata = convertKana(hira, { mode: 'katakana' });
+    expect(kata).toBe('ニホンゴ');
+  });
+
+  it('katakana → hiragana round-trip', () => {
+    const kata = convertKana('katakana', { mode: 'katakana' });
+    expect(kata).toBe('カタカナ');
+    const hira = convertKana(kata, { mode: 'hiragana' });
+    expect(hira).toBe('かたかな');
+  });
+
+  it('hiragana text under none mode is unchanged', () => {
+    expect(convertKana('にほんご', { mode: 'none' })).toBe('にほんご');
+  });
+
+  it('katakana text under none mode is unchanged', () => {
+    expect(convertKana('ニホンゴ', { mode: 'none' })).toBe('ニホンゴ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// None mode
+// ---------------------------------------------------------------------------
+describe('convertKana – none mode', () => {
+  it('returns original text unchanged', () => {
     expect(convertKana('abc', { mode: 'none' })).toBe('abc');
+  });
+
+  it('returns mixed kana unchanged', () => {
+    const mixed = 'にほんごNihongo';
+    expect(convertKana(mixed, { mode: 'none' })).toBe(mixed);
   });
 });

--- a/src/lib/reader.test.ts
+++ b/src/lib/reader.test.ts
@@ -1,24 +1,114 @@
-﻿import { describe, expect, it } from 'vitest';
-import { parseFuriganaGroups, parsePairs } from './reader';
+import { describe, expect, it } from 'vitest';
+import { hasJapaneseChars, looksEnglish, parseFuriganaGroups, parsePairs } from './reader';
 
+// ---------------------------------------------------------------------------
+// hasJapaneseChars
+// ---------------------------------------------------------------------------
+describe('hasJapaneseChars', () => {
+  it('returns true for hiragana', () => {
+    expect(hasJapaneseChars('こんにちは')).toBe(true);
+  });
+
+  it('returns true for katakana', () => {
+    expect(hasJapaneseChars('カタカナ')).toBe(true);
+  });
+
+  it('returns true for kanji', () => {
+    expect(hasJapaneseChars('日本語')).toBe(true);
+  });
+
+  it('returns false for plain romaji', () => {
+    expect(hasJapaneseChars('nihongo')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(hasJapaneseChars('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// looksEnglish
+// ---------------------------------------------------------------------------
+describe('looksEnglish', () => {
+  it('returns true for an English sentence', () => {
+    expect(looksEnglish('Hello, world!')).toBe(true);
+  });
+
+  it('returns false for hiragana line', () => {
+    expect(looksEnglish('こんにちは')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(looksEnglish('')).toBe(false);
+  });
+
+  it('returns false for a single latin letter', () => {
+    expect(looksEnglish('a')).toBe(false);
+  });
+
+  it('returns true for two or more latin letters', () => {
+    expect(looksEnglish('OK')).toBe(true);
+  });
+
+  it('returns false for mixed kanji + romaji that has Japanese', () => {
+    expect(looksEnglish('日本語 is cool')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePairs
+// ---------------------------------------------------------------------------
 describe('parsePairs', () => {
-  it('pairs JP + EN lines and allows blanks', () => {
+  it('pairs JP + EN lines', () => {
+    const pairs = parsePairs('こんにちは\nHello');
+    expect(pairs).toEqual([{ jp: 'こんにちは', en: 'Hello' }]);
+  });
+
+  it('allows blank lines between pairs', () => {
     const input = 'こんにちは\nHello\n\nさようなら\nGoodbye';
-    const pairs = parsePairs(input);
-    expect(pairs).toEqual([
+    expect(parsePairs(input)).toEqual([
       { jp: 'こんにちは', en: 'Hello' },
       { jp: 'さようなら', en: 'Goodbye' },
     ]);
   });
 
-  it('treats next JP line as JP when no English', () => {
+  it('treats next JP line as JP when no English follows', () => {
     const input = '日本語\n仮名\nHello';
     const pairs = parsePairs(input);
     expect(pairs[0]).toEqual({ jp: '日本語', en: '' });
     expect(pairs[1]).toEqual({ jp: '仮名', en: 'Hello' });
   });
+
+  it('handles trailing JP with no EN', () => {
+    const pairs = parsePairs('日本語\n');
+    expect(pairs).toEqual([{ jp: '日本語', en: '' }]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parsePairs('')).toEqual([]);
+    expect(parsePairs('\n\n\n')).toEqual([]);
+  });
+
+  it('handles CRLF line endings', () => {
+    const pairs = parsePairs('日本語\r\nJapanese');
+    expect(pairs).toEqual([{ jp: '日本語', en: 'Japanese' }]);
+  });
+
+  it('handles CR-only line endings', () => {
+    const pairs = parsePairs('日本語\rJapanese');
+    expect(pairs).toEqual([{ jp: '日本語', en: 'Japanese' }]);
+  });
+
+  it('handles multiple consecutive blank lines', () => {
+    const input = 'こんにちは\n\n\n\nHello';
+    const pairs = parsePairs(input);
+    expect(pairs).toEqual([{ jp: 'こんにちは', en: 'Hello' }]);
+  });
 });
 
+// ---------------------------------------------------------------------------
+// parseFuriganaGroups
+// ---------------------------------------------------------------------------
 describe('parseFuriganaGroups', () => {
   it('extracts base + reading tokens', () => {
     const tokens = parseFuriganaGroups('よくできた(作品 (さくひん))だ。', false);
@@ -26,10 +116,57 @@ describe('parseFuriganaGroups', () => {
     expect(furi).toEqual({ t: 'furi', base: '作品', reading: 'さくひん' });
   });
 
-  it('keeps parentheses when requested', () => {
+  it('keeps surrounding text tokens', () => {
+    const tokens = parseFuriganaGroups('よくできた(作品 (さくひん))だ。', false);
+    expect(tokens[0]).toEqual({ t: 'text', v: 'よ' });
+  });
+
+  it('keeps parentheses when keepParens is true', () => {
     const tokens = parseFuriganaGroups('(作品 (さくひん))', true);
     expect(tokens[0]).toEqual({ t: 'text', v: '(' });
     expect(tokens[1]).toEqual({ t: 'furi', base: '作品', reading: 'さくひん' });
     expect(tokens[2]).toEqual({ t: 'text', v: ')' });
+  });
+
+  it('omits parentheses when keepParens is false', () => {
+    const tokens = parseFuriganaGroups('(作品 (さくひん))', false);
+    expect(tokens[0]).toEqual({ t: 'furi', base: '作品', reading: 'さくひん' });
+    expect(tokens.some((t) => t.t === 'text' && t.v === '(')).toBe(false);
+  });
+
+  it('handles multiple furigana groups in one string', () => {
+    const tokens = parseFuriganaGroups('(日本 (にほん))(語 (ご))', false);
+    const furis = tokens.filter((t) => t.t === 'furi');
+    expect(furis).toHaveLength(2);
+    expect(furis[0]).toEqual({ t: 'furi', base: '日本', reading: 'にほん' });
+    expect(furis[1]).toEqual({ t: 'furi', base: '語', reading: 'ご' });
+  });
+
+  it('treats unclosed outer paren as plain text', () => {
+    // "(作品 (さくひん)" — missing outer closing paren
+    const tokens = parseFuriganaGroups('(作品 (さくひん)', false);
+    const text = tokens
+      .filter((t) => t.t === 'text')
+      .map((t) => (t.t === 'text' ? t.v : ''))
+      .join('');
+    expect(text).toContain('(');
+    expect(tokens.every((t) => t.t !== 'furi')).toBe(true);
+  });
+
+  it('returns plain text tokens for string with no furigana', () => {
+    const tokens = parseFuriganaGroups('こんにちは', false);
+    expect(tokens.every((t) => t.t === 'text')).toBe(true);
+    const text = tokens.map((t) => (t.t === 'text' ? t.v : '')).join('');
+    expect(text).toBe('こんにちは');
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseFuriganaGroups('', false)).toEqual([]);
+  });
+
+  it('trims whitespace from base and reading', () => {
+    const tokens = parseFuriganaGroups('( 作品  ( さくひん ))', false);
+    const furi = tokens.find((t) => t.t === 'furi');
+    expect(furi).toEqual({ t: 'furi', base: '作品', reading: 'さくひん' });
   });
 });

--- a/src/lib/useTts.test.ts
+++ b/src/lib/useTts.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTts } from './useTts';
+
+// ---------------------------------------------------------------------------
+// jsdom stubs for Web Speech API
+// ---------------------------------------------------------------------------
+
+class MockSpeechSynthesisUtterance {
+  text: string;
+  voice: SpeechSynthesisVoice | null = null;
+  lang = 'ja-JP';
+  rate = 1;
+  pitch = 1;
+  volume = 1;
+  onerror: (() => void) | null = null;
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+
+// Install/remove on the global object
+function installUtteranceStub() {
+  Object.defineProperty(window, 'SpeechSynthesisUtterance', {
+    value: MockSpeechSynthesisUtterance,
+    writable: true,
+    configurable: true,
+  });
+}
+function removeUtteranceStub() {
+  Object.defineProperty(window, 'SpeechSynthesisUtterance', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function makeSpeechSynthesisMock() {
+  let _onvoiceschanged: (() => void) | null = null;
+  const voices: SpeechSynthesisVoice[] = [
+    {
+      name: 'Google US English',
+      lang: 'en-US',
+      default: true,
+      localService: false,
+      voiceURI: 'Google US English',
+    },
+    {
+      name: 'Google 日本語',
+      lang: 'ja-JP',
+      default: false,
+      localService: false,
+      voiceURI: 'Google 日本語',
+    },
+  ] as SpeechSynthesisVoice[];
+
+  const synth = {
+    getVoices: vi.fn(() => voices),
+    speak: vi.fn(),
+    cancel: vi.fn(),
+    resume: vi.fn(),
+    get onvoiceschanged() {
+      return _onvoiceschanged;
+    },
+    set onvoiceschanged(cb: (() => void) | null) {
+      _onvoiceschanged = cb;
+    },
+    triggerVoicesChanged() {
+      _onvoiceschanged?.();
+    },
+  };
+  return { synth, voices };
+}
+
+function installSynth(synth: ReturnType<typeof makeSpeechSynthesisMock>['synth']) {
+  Object.defineProperty(window, 'speechSynthesis', {
+    value: synth,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function removeSynth() {
+  // Delete so that `'speechSynthesis' in window` returns false
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).speechSynthesis;
+  } catch {
+    Object.defineProperty(window, 'speechSynthesis', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useTts', () => {
+  beforeEach(() => {
+    installUtteranceStub();
+  });
+
+  afterEach(() => {
+    removeUtteranceStub();
+    vi.restoreAllMocks();
+  });
+
+  it('starts with status locked', () => {
+    const { synth } = makeSpeechSynthesisMock();
+    synth.getVoices.mockReturnValue([]);
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    expect(result.current.status).toBe('locked');
+    expect(result.current.ready).toBe(false);
+  });
+
+  it('sets status to unsupported when speechSynthesis is absent', () => {
+    removeSynth();
+    const { result } = renderHook(() => useTts());
+    expect(result.current.status).toBe('unsupported');
+  });
+
+  it('loads voices on mount when already available', () => {
+    const { synth, voices } = makeSpeechSynthesisMock();
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    expect(result.current.voices).toEqual(voices);
+    expect(result.current.selectedVoice).toBe(voices[0].name);
+  });
+
+  it('loads voices via onvoiceschanged when not available at mount', () => {
+    const { synth, voices } = makeSpeechSynthesisMock();
+    synth.getVoices.mockReturnValueOnce([]); // empty on first call
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    expect(result.current.voices).toHaveLength(0);
+
+    act(() => {
+      synth.triggerVoicesChanged();
+    });
+
+    expect(result.current.voices).toEqual(voices);
+    expect(result.current.selectedVoice).toBe(voices[0].name);
+  });
+
+  it('init() sets status to ready', () => {
+    const { synth } = makeSpeechSynthesisMock();
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    act(() => {
+      result.current.init();
+    });
+    expect(result.current.status).toBe('ready');
+    expect(result.current.ready).toBe(true);
+  });
+
+  it('setSelectedVoice updates selectedVoice without re-running loadVoicesNow', () => {
+    const { synth, voices } = makeSpeechSynthesisMock();
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    const callsBefore = synth.getVoices.mock.calls.length;
+
+    act(() => {
+      result.current.setSelectedVoice(voices[1].name);
+    });
+
+    expect(result.current.selectedVoice).toBe(voices[1].name);
+    // loadVoicesNow must NOT be called again just because selectedVoice changed
+    expect(synth.getVoices.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('speak() calls speechSynthesis.speak', () => {
+    const { synth } = makeSpeechSynthesisMock();
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    act(() => {
+      result.current.init();
+    });
+    act(() => {
+      result.current.speak('にほんご');
+    });
+
+    expect(synth.speak).toHaveBeenCalledOnce();
+    const utter = synth.speak.mock.calls[0][0] as MockSpeechSynthesisUtterance;
+    expect(utter.text).toBe('にほんご');
+  });
+
+  it('speak() does nothing for empty text', () => {
+    const { synth } = makeSpeechSynthesisMock();
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    act(() => {
+      result.current.init();
+    });
+    act(() => {
+      result.current.speak('');
+    });
+
+    expect(synth.speak).not.toHaveBeenCalled();
+  });
+
+  it('speak() uses the selected voice', () => {
+    const { synth, voices } = makeSpeechSynthesisMock();
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    act(() => {
+      result.current.init();
+    });
+    act(() => {
+      result.current.setSelectedVoice(voices[1].name);
+    });
+    act(() => {
+      result.current.speak('テスト');
+    });
+
+    const utter = synth.speak.mock.calls[0][0] as MockSpeechSynthesisUtterance;
+    expect(utter.voice).toBe(voices[1]);
+  });
+});

--- a/src/lib/useTts.ts
+++ b/src/lib/useTts.ts
@@ -35,11 +35,11 @@ export function useTts() {
     if (list && list.length) {
       voicesRef.current = list;
       setVoices(list);
-      if (!selectedVoice) setSelectedVoice(list[0].name);
+      setSelectedVoice((prev) => prev || list[0].name);
       return true;
     }
     return false;
-  }, [selectedVoice]);
+  }, []);
 
   useEffect(() => {
     if (!('speechSynthesis' in window)) {

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -136,7 +136,7 @@ export default function Reader() {
   useEffect(() => {
     if (!pairs.length) return;
     setOpenStates(pairs.map(() => showAllEn));
-  }, [showAllEn, pairs.length]);
+  }, [showAllEn, pairs]);
 
   const parsedOutput = useMemo(() => {
     return pairs.map((pair) => ({


### PR DESCRIPTION
## Summary

- Fixes a dependency cycle in `useTts` that caused `onvoiceschanged` to be torn down and re-registered on every voice dropdown change.
- Fixes IME suggestion popup arrow keys so Down wraps to first item and Up wraps to last.
- Fixes `Reader` `openStates` effect depending on `pairs.length` instead of `pairs` reference, which missed same-length pair replacements.
- Expands test coverage from 8 tests to 63 across three files; adds new `useTts.test.ts`.
- Rewrites README with accurate project info, architecture overview, and development commands.

## Linked Issue

Closes https://github.com/shikarii/kana-site/issues/3

## Base Branch

- [x] This PR targets `develop`

## Validation

- [x] `npm run test:run` — 63 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint:check` — clean
- [x] `npm run build` — succeeds
- [x] `bash docker/scripts/ci_full.sh` — all checks passed

## Risks and Tradeoffs

Low risk. All three fixes are mechanical:
- `useTts` change is a functional-update idiom that removes a dep without changing behavior.
- Arrow wrap change is pure arithmetic.
- `pairs.length` → `pairs` makes the dep more precise, not less.

No user-visible behavior changes except the arrow wrap fix (which is a UX improvement).

## Adversarial Review

- Verified `loadVoicesNow` still only sets `selectedVoice` on the first load (functional `prev || first` guard).
- Verified `pairs` as a dep does not cause spurious `openStates` resets — `pairs` is set from state and only changes on explicit `setPairs` calls.
- `SpeechSynthesisUtterance` is not in jsdom; mocked it in tests to avoid test environment issues.