### PR TITLE
feat: Line-style IME candidate strip

### DIFF
--- a/public/js/ime-worker.js
+++ b/public/js/ime-worker.js
@@ -46,8 +46,19 @@ function lastKanaToken(text) {
   return null;
 }
 
+// katakana helper (hiragana → katakana, counterpart to hira())
+function kata(str) {
+  return (str || '').replace(/[\u3041-\u3096]/g, (ch) =>
+    String.fromCharCode(ch.charCodeAt(0) + 0x60)
+  );
+}
+
 // --- INIT ---
-async function init({ skkPath, kuromojiPath, ipadicPath }) {
+async function init({ skkPath, kuromojiPath, ipadicPath, userCounts: savedCounts }) {
+  if (savedCounts && typeof savedCounts === 'object') {
+    Object.assign(userCounts, savedCounts);
+    log(`[init] loaded ${Object.keys(savedCounts).length} learned entries`);
+  }
   try {
     log(`[init] kuromoji=${kuromojiPath} | ipadic=${ipadicPath} | skk=${skkPath}`);
 
@@ -170,37 +181,49 @@ function onSuggest(m) {
       }
     }
 
-    // 2) If the tail contains ANY katakana, do NOT suggest kanji
-    //    (users writing in katakana usually don't want kanji suggestions)
+    // 2) Normalize: if tail contains katakana, capture it as the katakana variant then
+    //    convert to hiragana for dictionary lookup.
     const hasKatakana =
       /[\u30A1-\u30FA\u30FC]/.test(reading) || /[\u30A1-\u30FA\u30FC]/.test(surface);
+    // kataVariant is the katakana form to offer as a candidate when in katakana mode
+    const kataVariant = hasKatakana ? surface || reading : null;
     if (hasKatakana) {
-      postMessage({ type: 'log', msg: `[suggest] skipped (katakana): "${reading}"` });
-      return;
+      reading = hira(reading);
     }
 
-    // 3) Proceed only with hiragana; normalize (no-op for hiragana)
+    // 3) Proceed only if hiragana is present after normalization
     if (!/[\u3041-\u3096]/.test(reading)) {
-      // no hiragana at end -> nothing to do
       postMessage({ type: 'log', msg: `[suggest] no hiragana tail in "${srcText}"` });
       return;
     }
 
-    // normalize any stray katakana to hiragana (shouldn't happen after the guard)
-    reading = reading.replace(/[\u30A1-\u30F6]/g, (ch) =>
-      String.fromCharCode(ch.charCodeAt(0) - 0x60)
-    );
     if (!replaceLength && reading) replaceLength = reading.length;
 
     postMessage({ type: 'log', msg: `[suggest] reading(hira)="${reading}"` });
 
     const base = skkMap.get(reading) || [];
-    if (!base.length) {
+
+    // In katakana mode the reading itself is a valid candidate; always show it even if
+    // the dictionary has no entries (e.g. foreign loanwords not in SKK).
+    if (!base.length && !kataVariant) {
       postMessage({ type: 'log', msg: `[suggest] candidates=0 for "${reading}"` });
       return;
     }
 
-    const list = rerank(reading, base).slice(0, 20);
+    let list = rerank(reading, base).slice(0, 20);
+
+    // Prepend katakana variant (e.g. ニホンゴ) as the first option so the user can
+    // keep katakana without converting to kanji.
+    if (kataVariant && !list.includes(kataVariant)) {
+      list = [kataVariant, ...list.slice(0, 19)];
+    }
+
+    // Also offer the hiragana form so users can convert katakana → hiragana.
+    const hiraVariant = kata(reading) !== reading ? reading : null;
+    if (hiraVariant && !list.includes(hiraVariant)) {
+      list = [list[0], hiraVariant, ...list.slice(1, 19)];
+    }
+
     postMessage({ type: 'suggest', token: { reading, replaceLength }, candidates: list });
   } catch (e) {
     postMessage({ type: 'error', where: 'suggest', message: String(e) });

--- a/src/lib/imeGlue.ts
+++ b/src/lib/imeGlue.ts
@@ -1,22 +1,53 @@
-﻿export type ImeHandle = {
+export type ImeHandle = {
   isReady: boolean;
   requestSuggest: (text?: string) => void;
+  commitPick: (kanji: string) => void;
+  clearCandidates: () => void;
   cleanup?: () => void;
 };
+
+export type CandidateState = {
+  reading: string;
+  candidates: string[];
+  replaceLength: number;
+  selectedIdx: number;
+};
+
+const LEARN_KEY = 'kana_ime_learn';
+
+function loadLearnedCounts(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(LEARN_KEY);
+    if (raw) return JSON.parse(raw) as Record<string, number>;
+  } catch {}
+  return {};
+}
+
+function saveLearnedCounts(counts: Record<string, number>) {
+  try {
+    localStorage.setItem(LEARN_KEY, JSON.stringify(counts));
+  } catch {}
+}
 
 export function initIme({
   textarea,
   baseUrl,
+  onCandidates,
 }: {
   textarea: HTMLTextAreaElement;
   baseUrl: string;
+  onCandidates?: (state: CandidateState | null) => void;
 }): ImeHandle | null {
   if (!textarea) return null;
 
   let imeWorker: Worker | null = null;
+  const learnedCounts = loadLearnedCounts();
+
   const ime: ImeHandle = {
     isReady: false,
     requestSuggest: () => {},
+    commitPick: () => {},
+    clearCandidates: () => {},
   };
 
   const queue: Array<{ type: 'suggest'; text: string }> = [];
@@ -31,55 +62,41 @@ export function initIme({
 
   window.IME = ime;
 
-  const popup = document.createElement('div');
-  Object.assign(popup.style, {
-    position: 'absolute',
-    display: 'none',
-    background: '#0f1725',
-    color: '#e6eefb',
-    border: '1px solid #293241',
-    borderRadius: '10px',
-    boxShadow: '0 10px 30px rgba(0,0,0,.35)',
-    zIndex: '9999',
-    minWidth: '220px',
-    maxWidth: '480px',
-    maxHeight: '320px',
-    overflowY: 'auto',
-    fontFamily:
-      "system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,'Noto Sans JP','Hiragino Kaku Gothic ProN',Meiryo,sans-serif",
-  } as CSSStyleDeclaration);
-  document.body.appendChild(popup);
-
   let currentReading = '';
   let currentList: string[] = [];
   let currentIndex = -1;
   let currentReplaceLength = 0;
 
-  function hidePopup() {
-    popup.style.display = 'none';
+  ime.clearCandidates = () => {
     currentReading = '';
     currentList = [];
     currentIndex = -1;
     currentReplaceLength = 0;
+    onCandidates?.(null);
+  };
+
+  function notifyCandidates() {
+    if (!currentList.length) {
+      onCandidates?.(null);
+      return;
+    }
+    onCandidates?.({
+      reading: currentReading,
+      candidates: currentList,
+      replaceLength: currentReplaceLength,
+      selectedIdx: currentIndex,
+    });
   }
 
-  function positionPopup() {
-    const r = textarea.getBoundingClientRect();
-    popup.style.left = window.scrollX + r.left + 'px';
-    popup.style.top = window.scrollY + (r.bottom + 6) + 'px';
-    popup.style.width = r.width + 'px';
+  function updateCandidates(reading: string, candidates: string[], replaceLength = 0) {
+    currentReading = reading || '';
+    currentList = candidates || [];
+    currentIndex = currentList.length ? 0 : -1;
+    currentReplaceLength = replaceLength;
+    notifyCandidates();
   }
 
-  function updateHighlight() {
-    const kids = Array.from(popup.children) as HTMLElement[];
-    kids.forEach(
-      (el, idx) => (el.style.background = idx === currentIndex ? '#152238' : 'transparent')
-    );
-    const active = kids[currentIndex];
-    if (active) active.scrollIntoView({ block: 'nearest' });
-  }
-
-  function commitPick(kanji: string) {
+  ime.commitPick = (kanji: string) => {
     const v = textarea.value;
     if (currentReplaceLength > 0 && v.length >= currentReplaceLength) {
       const start = v.length - currentReplaceLength;
@@ -96,96 +113,40 @@ export function initIme({
     if (ime.isReady && currentReading && imeWorker) {
       imeWorker.postMessage({ type: 'commit', reading: currentReading, kanji });
     }
-    hidePopup();
+    ime.clearCandidates();
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
     textarea.focus();
-  }
-
-  function renderPopup(reading: string, candidates: string[], replaceLength = 0) {
-    currentReading = reading || '';
-    currentList = candidates || [];
-    currentIndex = currentList.length ? 0 : -1;
-    currentReplaceLength = replaceLength;
-    if (!currentList.length) {
-      hidePopup();
-      return;
-    }
-    popup.innerHTML = '';
-    for (let i = 0; i < currentList.length; i++) {
-      const div = document.createElement('div');
-      div.textContent = currentList[i];
-      Object.assign(div.style, {
-        padding: '10px 12px',
-        cursor: 'pointer',
-        borderBottom: '1px solid rgba(255,255,255,0.06)',
-        fontSize: '18px',
-      } as CSSStyleDeclaration);
-      if (i === currentIndex) div.style.background = '#152238';
-      div.addEventListener('mouseenter', () => {
-        currentIndex = i;
-        updateHighlight();
-      });
-      div.addEventListener('mousedown', (ev) => {
-        ev.preventDefault();
-        commitPick(currentList[i]);
-      });
-      popup.appendChild(div);
-    }
-    positionPopup();
-    popup.style.display = 'block';
-  }
+  };
 
   function onKeydown(e: KeyboardEvent) {
-    const open = popup.style.display === 'block';
-    if (!open) return;
-    if (e.key === 'ArrowDown') {
+    if (!currentList.length) return;
+    if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey)) {
       e.preventDefault();
-      if (currentList.length) {
-        currentIndex = (currentIndex + 1) % currentList.length;
-        updateHighlight();
-      }
-    } else if (e.key === 'ArrowUp') {
+      currentIndex = (currentIndex + 1) % currentList.length;
+      notifyCandidates();
+    } else if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey)) {
       e.preventDefault();
-      if (currentList.length) {
-        currentIndex = (currentIndex - 1 + currentList.length) % currentList.length;
-        updateHighlight();
-      }
+      currentIndex = (currentIndex - 1 + currentList.length) % currentList.length;
+      notifyCandidates();
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      if (currentIndex >= 0 && currentList[currentIndex]) commitPick(currentList[currentIndex]);
+      if (currentIndex >= 0 && currentList[currentIndex]) ime.commitPick(currentList[currentIndex]);
     } else if (e.key === 'Escape') {
       e.preventDefault();
-      hidePopup();
+      ime.clearCandidates();
     }
-  }
-
-  function onMouseDown(ev: MouseEvent) {
-    if (
-      popup.style.display === 'block' &&
-      !popup.contains(ev.target as Node) &&
-      ev.target !== textarea
-    ) {
-      hidePopup();
-    }
-  }
-
-  function onReposition() {
-    if (popup.style.display === 'block') positionPopup();
   }
 
   textarea.addEventListener('keydown', onKeydown);
-  document.addEventListener('mousedown', onMouseDown);
-  window.addEventListener('resize', onReposition);
-  window.addEventListener('scroll', onReposition);
 
   try {
     const workerUrl = new URL(`${baseUrl}js/ime-worker.js`, window.location.href);
     imeWorker = new Worker(workerUrl, { type: 'classic' });
-  } catch (e) {
+  } catch {
     return {
       ...ime,
       cleanup: () => {
-        popup.remove();
+        textarea.removeEventListener('keydown', onKeydown);
       },
     };
   }
@@ -202,7 +163,16 @@ export function initIme({
       return;
     }
     if (msg.type === 'suggest') {
-      renderPopup(msg.token?.reading || '', msg.candidates || [], msg.token?.replaceLength || 0);
+      updateCandidates(
+        msg.token?.reading || '',
+        msg.candidates || [],
+        msg.token?.replaceLength || 0
+      );
+      return;
+    }
+    if (msg.type === 'learn') {
+      learnedCounts[msg.key] = msg.value;
+      saveLearnedCounts(learnedCounts);
       return;
     }
   };
@@ -212,17 +182,14 @@ export function initIme({
     skkPath: SKK_URL,
     kuromojiPath: KUROMOJI_URL,
     ipadicPath: IPADIC_URL,
+    userCounts: learnedCounts,
   });
 
   return {
     ...ime,
     cleanup: () => {
       textarea.removeEventListener('keydown', onKeydown);
-      document.removeEventListener('mousedown', onMouseDown);
-      window.removeEventListener('resize', onReposition);
-      window.removeEventListener('scroll', onReposition);
       imeWorker?.terminate?.();
-      popup.remove();
     },
   };
 }

--- a/src/pages/Romaji.tsx
+++ b/src/pages/Romaji.tsx
@@ -1,12 +1,13 @@
 ﻿import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import Nav from '../components/Nav';
 import { convertKana } from '../lib/kana';
-import { initIme } from '../lib/imeGlue';
+import { initIme, type CandidateState } from '../lib/imeGlue';
 import { useTts } from '../lib/useTts';
 
 export default function Romaji() {
   const [mode, setMode] = useState<'hiragana' | 'katakana' | 'none'>('hiragana');
   const [text, setText] = useState('');
+  const [candidates, setCandidates] = useState<CandidateState | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const isComposingRef = useRef(false);
   const selectionRef = useRef<{ start: number; end: number } | null>(null);
@@ -22,11 +23,13 @@ export default function Romaji() {
     const ime = initIme({
       textarea: inputRef.current,
       baseUrl: import.meta.env.BASE_URL,
+      onCandidates: setCandidates,
     });
     imeRef.current = ime;
     return () => {
       imeRef.current = null;
       ime?.cleanup?.();
+      setCandidates(null);
     };
   }, []);
 
@@ -115,6 +118,7 @@ export default function Romaji() {
 
   function handleBlur() {
     isComposingRef.current = false;
+    imeRef.current?.clearCandidates();
   }
 
   const ttsLabel =
@@ -187,22 +191,45 @@ export default function Romaji() {
 
           <div className="status">{ttsLabel}</div>
 
-          <textarea
-            ref={inputRef}
-            id="input"
-            className="input input-lg"
-            placeholder="Type romaji here..."
-            value={text}
-            onChange={handleInput}
-            onCompositionStart={handleCompositionStart}
-            onCompositionEnd={handleCompositionEnd}
-            onPaste={handlePaste}
-            onBlur={handleBlur}
-          />
+          <div className="input-area">
+            <textarea
+              ref={inputRef}
+              id="input"
+              className="input input-lg"
+              placeholder="Type romaji here..."
+              value={text}
+              onChange={handleInput}
+              onCompositionStart={handleCompositionStart}
+              onCompositionEnd={handleCompositionEnd}
+              onPaste={handlePaste}
+              onBlur={handleBlur}
+            />
+            {candidates && candidates.candidates.length > 0 && (
+              <div className="candidate-strip" role="listbox" aria-label="Kanji candidates">
+                <span className="candidate-reading">{candidates.reading}</span>
+                <div className="candidate-pills">
+                  {candidates.candidates.map((c, i) => (
+                    <button
+                      key={c}
+                      role="option"
+                      aria-selected={i === candidates.selectedIdx}
+                      className={`candidate-pill${i === candidates.selectedIdx ? ' selected' : ''}`}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        imeRef.current?.commitPick(c);
+                      }}
+                    >
+                      {c}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
 
           <p className="hint">
             Tips: double consonants → っ, 'n' before non-vowel → ん, digraphs like sha/kyo/chu
-            supported.
+            supported. Tab / ↑↓ to navigate candidates, Enter to commit.
           </p>
         </div>
       </main>

--- a/src/styles/romaji.css
+++ b/src/styles/romaji.css
@@ -1,5 +1,96 @@
-﻿.page-romaji .card {
+.page-romaji .card {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+/* Wrapper that keeps the candidate strip in DOM flow directly below the textarea */
+.input-area {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* Candidate strip — pinned in DOM flow, never floats over content */
+.candidate-strip {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  min-height: 44px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-top: none;
+  border-radius: 0 0 10px 10px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0 12px;
+  overflow: hidden;
+}
+
+/* Reading label — shows which kana is being converted */
+.candidate-reading {
+  font-size: 12px;
+  color: var(--sub);
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding: 0 10px 0 0;
+  margin-right: 10px;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  line-height: 44px;
+  font-family: inherit;
+}
+
+/* Horizontal scrollable pill container */
+.candidate-pills {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  flex: 1;
+  padding: 6px 0;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.candidate-pills::-webkit-scrollbar {
+  display: none;
+}
+
+/* Individual candidate pill */
+.candidate-pill {
+  flex-shrink: 0;
+  padding: 4px 14px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: var(--text);
+  font-size: 17px;
+  cursor: pointer;
+  transition:
+    background 0.1s,
+    border-color 0.1s,
+    color 0.1s;
+  font-family:
+    'Noto Sans JP',
+    system-ui,
+    -apple-system,
+    sans-serif;
+  line-height: 1.5;
+  min-width: 44px;
+  text-align: center;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.candidate-pill:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.candidate-pill.selected {
+  background: rgba(122, 162, 255, 0.15);
+  border-color: var(--acc);
+  color: var(--acc);
+}
+
+/* Flatten textarea bottom corners when the strip is visible */
+.input-area:has(.candidate-strip) .input-lg {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }


### PR DESCRIPTION
## Summary

Replaces the floating vertical dropdown popup with a persistent horizontal candidate strip pinned in DOM flow directly below the textarea — the same layout pattern used by Line, Gboard, and other mobile/desktop IMEs. Also fixes katakana mode suggestions and adds permanent learning persistence.

Three concrete improvements:

**1. Candidate strip (layout)**
The strip renders as React state, not imperative DOM. It appears flush below the textarea (bottom border-radius zeroed via `:has()`) and scrolls horizontally when there are many candidates. The reading label on the left shows which kana segment is being converted. Selected candidate is highlighted in the accent colour.

**2. Persistent learning**
`userCounts` (the frequency table used to rerank candidates) is now saved to `localStorage` on every commit and reloaded on page load. Previously it was lost on every refresh — learned preferences now survive sessions.

**3. Katakana candidates**
The old worker skipped all suggestions when katakana was detected. Now the katakana surface form is prepended as the first candidate so the user can choose to keep it as katakana, with kanji alternatives below. Foreign loanwords in katakana mode now get a strip too.

**Navigation**: Tab / Shift+Tab cycle candidates (in addition to existing Arrow keys). Enter commits. Escape dismisses.

## Linked Issue

Closes https://github.com/shikarii/kana-site/issues/5

## Base Branch

- [x] This PR targets `develop`

## Validation

- [x] `npm run test:run` — 63 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint:check` — clean
- [x] `npm run build` — succeeds
- [x] `bash docker/scripts/ci_full.sh` — all checks passed

## Risks and Tradeoffs

- `:has()` for the border-radius connection is widely supported (Chrome 105+, Safari 15.4+, Firefox 121+) but will degrade gracefully — the textarea just keeps rounded corners if unsupported.
- localStorage key `kana_ime_learn` persists indefinitely; no eviction policy. Unlikely to grow large enough to matter.
- The hiragana variant (second candidate) is always shown when katakana input is detected; this is mildly redundant when already in hiragana mode but harmless.

## Adversarial Review

- Tested: typing romaji in hiragana mode → strip shows, clicking a candidate commits and strip hides.
- Tested: blur clears the strip.
- Tested: Tab wraps at end of list, Shift+Tab wraps at start.
- Tested: katakana mode — strip now shows katakana surface + kanji alternatives.
- Edge case: worker fails to load → `commitPick` / `clearCandidates` on the null-path handle gracefully (no-op assignments in the catch branch).