### PR TITLE
fix(ime): prevent premature n→ん conversion and default to Japanese TTS voice

### DIFF
--- a/src/lib/kana.test.ts
+++ b/src/lib/kana.test.ts
@@ -18,15 +18,33 @@ describe('convertKana – hiragana mode', () => {
     expect(convertKana('zasshi')).toBe('ざっし');
   });
 
-  it('n before non-vowel or at string boundary becomes ん', () => {
-    // wanakana converts every standalone n-before-n to ん
-    expect(convertKana('nihon')).toBe('にほん');
+  it('n before vowel forms the correct kana (not ん prematurely)', () => {
+    // The core bug: with IMEMode=true, 'n' before a vowel must NOT become ん first
+    expect(convertKana('nokoru')).toBe('のこる');  // was broken: んおる
     expect(convertKana('nani')).toBe('なに');
+    expect(convertKana('neko')).toBe('ねこ');
   });
 
-  it('n before non-vowel becomes ん', () => {
+  it('n before consonant (mid-word) becomes ん', () => {
     expect(convertKana('nka')).toBe('んか');
     expect(convertKana('tanki')).toBe('たんき');
+    expect(convertKana('nihongo')).toBe('にほんご'); // n before g
+  });
+
+  it('trailing n stays pending during live typing (IMEMode default)', () => {
+    // In live-typing mode trailing 'n' is NOT committed — user must type 'nn' or another consonant
+    expect(convertKana('nihon')).toBe('にほn');
+    expect(convertKana('n')).toBe('n');
+  });
+
+  it('nn commits to ん in live mode', () => {
+    expect(convertKana('nn')).toBe('ん');
+    expect(convertKana('nihonn')).toBe('にほん');
+  });
+
+  it('trailing n finalizes to ん with imeMode:false (on blur)', () => {
+    expect(convertKana('nihon', { imeMode: false })).toBe('にほん');
+    expect(convertKana('n', { imeMode: false })).toBe('ん');
   });
 
   it('digraphs – sha / chi / tsu', () => {
@@ -77,8 +95,21 @@ describe('convertKana – katakana mode', () => {
     expect(convertKana('katta', { mode: 'katakana' })).toBe('カッタ');
   });
 
-  it('nn produces ン', () => {
-    expect(convertKana('nihon', { mode: 'katakana' })).toBe('ニホン');
+  it('trailing n stays pending in live mode', () => {
+    expect(convertKana('nihon', { mode: 'katakana' })).toBe('ニホn');
+    expect(convertKana('nihon', { mode: 'katakana', imeMode: false })).toBe('ニホン');
+  });
+
+  it('nn produces ン in live mode', () => {
+    expect(convertKana('nihonn', { mode: 'katakana' })).toBe('ニホン');
+  });
+
+  it('extended katakana – vu / vo / va / vi / ve', () => {
+    expect(convertKana('vu', { mode: 'katakana' })).toBe('ヴ');
+    expect(convertKana('vo', { mode: 'katakana' })).toBe('ヴォ');
+    expect(convertKana('va', { mode: 'katakana' })).toBe('ヴァ');
+    expect(convertKana('vi', { mode: 'katakana' })).toBe('ヴィ');
+    expect(convertKana('ve', { mode: 'katakana' })).toBe('ヴェ');
   });
 
   it('converts hiragana to katakana', () => {

--- a/src/lib/kana.ts
+++ b/src/lib/kana.ts
@@ -18,14 +18,17 @@ function applyKatakanaLongVowels(kana: string) {
 
 export type KanaMode = 'hiragana' | 'katakana' | 'none';
 
-export function convertKana(input: string, { mode = 'hiragana' }: { mode?: KanaMode } = {}) {
+export function convertKana(
+  input: string,
+  { mode = 'hiragana', imeMode = true }: { mode?: KanaMode; imeMode?: boolean } = {}
+) {
   const s = (input ?? '').normalize('NFKC');
   if (mode === 'none') return s;
 
   if (mode === 'katakana') {
-    const base = toKatakana(s);
+    const base = toKatakana(s, { IMEMode: imeMode });
     return applyKatakanaLongVowels(toKatakanaStr(base));
   }
 
-  return toHiragana(s);
+  return toHiragana(s, { IMEMode: imeMode });
 }

--- a/src/lib/useTts.test.ts
+++ b/src/lib/useTts.test.ts
@@ -124,16 +124,18 @@ describe('useTts', () => {
     expect(result.current.status).toBe('unsupported');
   });
 
-  it('loads voices on mount when already available', () => {
+  it('loads voices on mount and defaults to the Japanese voice', () => {
     const { synth, voices } = makeSpeechSynthesisMock();
     installSynth(synth);
 
     const { result } = renderHook(() => useTts());
     expect(result.current.voices).toEqual(voices);
-    expect(result.current.selectedVoice).toBe(voices[0].name);
+    // Should pick the ja-JP voice (voices[1]) not the first English voice
+    expect(result.current.selectedVoice).toBe(voices[1].name);
+    expect(result.current.hasJaVoice).toBe(true);
   });
 
-  it('loads voices via onvoiceschanged when not available at mount', () => {
+  it('loads voices via onvoiceschanged and defaults to the Japanese voice', () => {
     const { synth, voices } = makeSpeechSynthesisMock();
     synth.getVoices.mockReturnValueOnce([]); // empty on first call
     installSynth(synth);
@@ -146,7 +148,20 @@ describe('useTts', () => {
     });
 
     expect(result.current.voices).toEqual(voices);
-    expect(result.current.selectedVoice).toBe(voices[0].name);
+    expect(result.current.selectedVoice).toBe(voices[1].name);
+  });
+
+  it('hasJaVoice is false when no Japanese voice is available', () => {
+    const { synth } = makeSpeechSynthesisMock();
+    synth.getVoices.mockReturnValue([
+      { name: 'Google US English', lang: 'en-US', default: true, localService: false, voiceURI: 'Google US English' } as SpeechSynthesisVoice,
+    ]);
+    installSynth(synth);
+
+    const { result } = renderHook(() => useTts());
+    expect(result.current.hasJaVoice).toBe(false);
+    // Falls back to list[0] when no Japanese voice
+    expect(result.current.selectedVoice).toBe('Google US English');
   });
 
   it('init() sets status to ready', () => {

--- a/src/lib/useTts.ts
+++ b/src/lib/useTts.ts
@@ -35,7 +35,11 @@ export function useTts() {
     if (list && list.length) {
       voicesRef.current = list;
       setVoices(list);
-      setSelectedVoice((prev) => prev || list[0].name);
+      setSelectedVoice((prev) => {
+        if (prev) return prev;
+        const jpVoice = list.find((v) => /ja/i.test(v.lang));
+        return (jpVoice || list[0]).name;
+      });
       return true;
     }
     return false;
@@ -107,11 +111,14 @@ export function useTts() {
     [getSelectedVoice]
   );
 
+  const hasJaVoice = voices.some((v) => /ja/i.test(v.lang));
+
   return {
     status,
     voices,
     selectedVoice,
     setSelectedVoice,
+    hasJaVoice,
     init,
     speak,
     ready,

--- a/src/pages/Romaji.tsx
+++ b/src/pages/Romaji.tsx
@@ -38,6 +38,7 @@ export default function Romaji() {
     voices,
     selectedVoice,
     setSelectedVoice,
+    hasJaVoice,
     init: initTts,
     speak,
     ready: ttsReady,
@@ -52,26 +53,26 @@ export default function Romaji() {
     selectionRef.current = null;
   }, [text]);
 
-  function convertAll(value: string, nextMode: typeof mode = mode) {
+  function convertAll(value: string, nextMode: typeof mode = mode, imeMode = true) {
     if (nextMode === 'none') return value;
-    return convertKana(value, { mode: nextMode });
+    return convertKana(value, { mode: nextMode, imeMode });
   }
 
-  function prefLen(value: string, cursor: number, nextMode: typeof mode = mode) {
-    return convertAll(value.slice(0, cursor), nextMode).length;
+  function prefLen(value: string, cursor: number, nextMode: typeof mode = mode, imeMode = true) {
+    return convertAll(value.slice(0, cursor), nextMode, imeMode).length;
   }
 
-  function applyConversion(value: string, nextMode: typeof mode = mode) {
+  function applyConversion(value: string, nextMode: typeof mode = mode, imeMode = true) {
     const el = inputRef.current;
     if (!el) return;
 
     const start = el.selectionStart ?? value.length;
     const end = el.selectionEnd ?? start;
-    const converted = convertAll(value, nextMode);
+    const converted = convertAll(value, nextMode, imeMode);
 
     if (converted !== value) {
-      const nextStart = prefLen(value, start, nextMode);
-      const nextEnd = prefLen(value, end, nextMode);
+      const nextStart = prefLen(value, start, nextMode, imeMode);
+      const nextEnd = prefLen(value, end, nextMode, imeMode);
       selectionRef.current = { start: nextStart, end: nextEnd };
       setText(converted);
       imeRef.current?.requestSuggest?.(converted);
@@ -119,6 +120,9 @@ export default function Romaji() {
   function handleBlur() {
     isComposingRef.current = false;
     imeRef.current?.clearCandidates();
+    // Commit any pending romaji (e.g. trailing 'n' → ん) on blur
+    const current = inputRef.current?.value ?? text;
+    applyConversion(current, mode, false);
   }
 
   const ttsLabel =
@@ -190,6 +194,12 @@ export default function Romaji() {
           </div>
 
           <div className="status">{ttsLabel}</div>
+          {ttsReady && voices.length > 0 && !hasJaVoice && (
+            <div className="status" style={{ color: 'var(--warn, #a07032)' }}>
+              No Japanese voice detected. Install a Japanese TTS voice in your OS language settings
+              for audio output.
+            </div>
+          )}
 
           <div className="input-area">
             <textarea


### PR DESCRIPTION
Closes https://github.com/shikarii/kana-site/issues/8

## Summary

- **Core IME bug fixed**: `convertKana` now uses `IMEMode: true` (wanakana) by default, which prevents typing `n` before a vowel from prematurely becoming `ん`. The regression `nokoru → んおる` is gone; it now correctly produces `のこる`.
- **Trailing-n finalization**: `handleBlur` in Romaji.tsx runs a final `imeMode: false` pass so any pending `n` at the end commits to `ん`/`ン` when the user leaves the field. Users can also type `nn` during input to force `ん` immediately.
- **TTS default voice**: `loadVoicesNow` now prefers the first `ja-*` voice over `list[0]`, so Japanese text actually speaks when a Japanese voice is installed.
- **No-Japanese-voice warning**: If the browser has no `ja-*` TTS voice at all, a visible warning is shown after enabling speech.
- **Extended katakana tests**: `vu / vo / va / vi / ve → ヴ / ヴォ / ヴァ / ヴィ / ヴェ` coverage added.

## Validation

`npm run test` — 69 tests, all passing.

## Test plan
- [ ] Type `nokoru` in hiragana mode → see `のこる` (not `んおる`)
- [ ] Type `nihon` → see `にほn` live; click elsewhere → finalizes to `にほん`
- [ ] Type `nihonn` → immediately gets `にほん`
- [ ] Type `va`, `vi`, `vu`, `ve`, `vo` in katakana mode → get `ヴァ`, `ヴィ`, `ヴ`, `ヴェ`, `ヴォ`
- [ ] Enable Speech → if no Japanese voice installed, see the warning message
- [ ] Enable Speech with Japanese voice → voice selector defaults to the Japanese voice