### PR TITLE
docs(agents): expand AGENTS.md for full-stack layout and add server/AGENT.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,18 @@ Do not introduce or modify licensing terms without explicit maintainer approval.
 
 ## 2. Module Ownership and Boundaries
 
+This repository is transitioning to a full-stack project. The top-level layout is:
+
+```
+src/            — frontend (Vite + React + TypeScript)
+server/         — backend (Hono + Drizzle + SQLite/PostgreSQL) — planned
+```
+
+Each package has its own `package.json`, `tsconfig.json`, and nested `AGENT.md`.
+The root `AGENTS.md` rules apply to both; inner `AGENT.md` files refine scope-specific rules.
+
+### 2.1 Frontend layout (`src/`)
+
 ```
 src/
   components/   — reusable UI primitives (no page-level state or routing)
@@ -43,12 +55,56 @@ src/
   styles/       — global CSS and design tokens
 ```
 
-Import rules:
+Frontend import rules:
 
 - `lib/` must not import from `components/`, `pages/`, or `styles/`.
 - `components/` must not import from `pages/`.
 - `pages/` may import from `components/` and `lib/`.
 - Side effects (DOM events, localStorage) belong in `pages/` or explicit hook modules, never in `lib/`.
+- `src/` must never import from `server/`.
+
+### 2.2 Server layout (`server/`) — planned
+
+```
+server/
+  src/
+    config/     — env loading + zod validation. No direct process.env elsewhere.
+    db/         — Drizzle schema, migration scripts, seed helpers
+    routes/     — Hono route handlers (thin: validate, call service, respond)
+    services/   — business logic (sentence import, search, tokenization)
+    lib/        — generic helpers (logger, errors). No domain knowledge.
+  tests/
+  package.json
+  tsconfig.json
+  AGENT.md
+```
+
+Server layer dependency direction (hard rule):
+
+- `db/` imports only from `db/` and `lib/`
+- `services/` imports from `db/` and `lib/`
+- `routes/` imports from `services/` and `lib/`
+- `lib/` imports nothing from the project
+
+Disallowed on the server:
+
+- Direct SQL/DB calls inside route handlers — go through `services/`.
+- `process.env` outside `config/`.
+- Business logic embedded in route handlers.
+
+### 2.3 API contract between frontend and server
+
+- All routes are under `/api/v1/`.
+- Request/response shapes are defined as TypeScript interfaces in `server/src/routes/types.ts` and
+  mirrored in `src/types/api.ts` on the frontend. Both must stay in sync.
+- The frontend never imports server modules. Types are duplicated or generated, not shared via import.
+
+### 2.4 Database rules
+
+- Schema is the single source of truth. All changes go through Drizzle migrations — never raw ALTER.
+- SQLite for local development; PostgreSQL-compatible Drizzle driver for production.
+- No raw SQL outside `db/` — use Drizzle query builder everywhere else.
+- Seed scripts belong in `server/src/db/seed.ts`, not mixed into migration files.
 
 ## 3. Quality and Enforcement
 
@@ -67,6 +123,7 @@ docker compose -f docker/docker-compose.yml --profile ci ps runner
 ```
 
 **If Docker is not running:** STOP. Notify the user immediately:
+
 > "Docker is not available. Please start Docker Desktop before proceeding.
 > The CI runner and local quality gates require Docker to function."
 > Do not commit, push, or open PRs until Docker is confirmed running.

--- a/server/AGENT.md
+++ b/server/AGENT.md
@@ -1,0 +1,103 @@
+# AGENT.md (server)
+
+Applies to `server/`. Root `AGENTS.md` rules apply first; this file tightens them for the
+backend package.
+
+## 1. Architecture
+
+This is a Hono (TypeScript) HTTP API backed by Drizzle ORM.
+
+Layers:
+
+- `src/config/`    Load and validate all env vars (zod). No other file reads `process.env`.
+- `src/db/`        Drizzle schema, migration scripts, query helpers. No business logic here.
+- `src/services/`  Business logic: sentence import, full-text search, tokenization (kuromoji).
+- `src/routes/`    Thin Hono handlers: validate input, call a service, return JSON. Max 30 lines each.
+- `src/lib/`       Generic helpers (logger, error classes). No domain knowledge.
+
+Dependency direction (hard rule):
+
+```
+lib  <-- db  <-- services  <-- routes
+```
+
+`routes` must never call `db` directly. `db` must never call `services`.
+
+## 2. Project layout
+
+```
+server/
+  src/
+    config/
+      env.ts           — zod env schema, validated at startup
+    db/
+      schema.ts        — Drizzle table definitions (single source of truth)
+      client.ts        — db connection singleton
+      migrate.ts       — migration runner entrypoint
+      seed.ts          — optional seed data
+    routes/
+      sentences.ts     — GET /api/v1/sentences, POST /api/v1/sentences/import
+      index.ts         — Hono app assembly and route registration
+      types.ts         — request/response interface types (mirrored in src/types/api.ts)
+    services/
+      sentenceService.ts   — CRUD and import logic
+      searchService.ts     — FTS query building
+    lib/
+      logger.ts
+      errors.ts
+  tests/
+    sentences.test.ts
+  package.json
+  tsconfig.json
+```
+
+## 3. File size limits
+
+- No file over 200 lines. Route files target 30-50 lines.
+- No function over 40 lines. Extract helpers.
+
+## 4. Route handler rules
+
+A route handler must only:
+
+1. Parse and validate the request (zod).
+2. Call exactly one service method.
+3. Return a typed JSON response.
+
+If a handler needs more, move the logic into a service.
+
+## 5. Database rules
+
+- Drizzle schema in `db/schema.ts` is the single source of truth.
+- Schema changes require a migration file — never hand-edit the SQLite file directly.
+- SQLite for local dev; same Drizzle schema works with PostgreSQL driver for production.
+- No raw SQL outside `db/`. Use Drizzle query builder everywhere.
+
+## 6. Sentence import format
+
+The `.txt` import format is JP/EN paired lines (same format the frontend Reader already
+understands). The import service must use the same `parsePairs` logic from `src/lib/reader.ts`
+or a copy of it — do not duplicate the parsing logic with different behavior.
+
+## 7. Search
+
+- SQLite FTS5 virtual table for full-text search across `japanese` and `english` columns.
+- Kuromoji (already in the repo as a web worker asset) may be loaded server-side for
+  morphological tokenization of search queries. Keep it behind `services/searchService.ts`.
+
+## 8. Testing expectations
+
+- All `services/` must have unit tests with a real (in-memory) SQLite database.
+- Route tests use `app.request(...)` (Hono test helper) — no live HTTP server.
+- No test may touch the filesystem or network.
+
+## 9. PR acceptance checklist
+
+A server PR is not acceptable unless:
+
+- No `process.env` calls outside `config/env.ts`.
+- No raw SQL outside `db/`.
+- Route handlers call exactly one service.
+- New service logic has unit tests.
+- `npm run build` and `npm run test` in `server/` pass clean.
+- `types.ts` in `routes/` and `src/types/api.ts` in the frontend are kept in sync.


### PR DESCRIPTION
Closes https://github.com/shikarii/kana-site/issues/9

## Summary

- Root `AGENTS.md` section 2 now documents both frontend (`src/`) and the planned server
  package (`server/`), including layer dependency rules, API contract conventions, and
  database rules.
- New `server/AGENT.md` defines the Hono + Drizzle server architecture: config/db/services/
  routes layers, file size limits, route handler rules, FTS5 search guidance, and testing
  expectations. Ready to enforce rules the moment scaffolding begins.

No runtime code changed. Documentation and governance only.

## Validation

No code changes — manual validation: AGENTS.md reviewed for correctness and consistency
with existing platform-server and dashboard AGENT.md patterns.