### PR TITLE
feat: kotoba-lab — Japanese sentence capture, browser extension, Ollama/k3d infra, Playwright CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Use real line breaks; do not include literal `\n` sequences.
 
 Use a closing keyword with a full URL (required):
 
-- Closes https://github.com/shikarii/kana-site/issues/<number>
+- Closes https://github.com/shikarii/kotoba-lab/issues/<number>
 
 ## Base Branch
 

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -30,8 +30,8 @@ jobs:
             exit 1
           fi
 
-          if ! grep -Eiq '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+https://github.com/[a-zA-Z0-9_-]+/kana-site/issues/[0-9]+' <<< "$body"; then
-            echo "Missing issue-closing link (e.g. 'Closes https://github.com/shikarii/kana-site/issues/1')."
+          if ! grep -Eiq '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+https://github.com/[a-zA-Z0-9_-]+/kotoba-lab/issues/[0-9]+' <<< "$body"; then
+            echo "Missing issue-closing link (e.g. 'Closes https://github.com/shikarii/kotoba-lab/issues/1')."
             exit 1
           fi
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -96,6 +96,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build client image
-        run: docker build -f docker/Dockerfile.client -t kana-client:ci .
+        run: docker build -f docker/Dockerfile.client -t kotoba-client:ci .
       - name: Build server image
-        run: docker build -f docker/Dockerfile.server -t kana-server:ci .
+        run: docker build -f docker/Dockerfile.server -t kotoba-server:ci .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ The top-level layout is:
 ```
 client/         — frontend (Vite + React + TypeScript)
 server/         — backend (Hono + Drizzle + SQLite)
-k8s/            — Kubernetes manifests (namespace kana)
+k8s/            — Kubernetes manifests (namespace kotoba)
 docker/         — CI, production Dockerfiles, nginx config
 ```
 
@@ -143,7 +143,7 @@ Run this check at the start of every session:
 docker info > /dev/null 2>&1 || echo "DOCKER NOT RUNNING"
 
 # 2. Check runner status (managed by shikarii/ci-infra)
-docker ps --filter "name=runner-kana" --format "{{.Names}}: {{.Status}}"
+docker ps --filter "name=runner-kotoba" --format "{{.Names}}: {{.Status}}"
 ```
 
 **If Docker is not running:** STOP. Notify the user immediately:
@@ -156,7 +156,7 @@ docker ps --filter "name=runner-kana" --format "{{.Names}}: {{.Status}}"
 Start them from that repo:
 
 ```bash
-cd ~/path/to/ci-infra && bash scripts/setup.sh runner-kana
+cd ~/path/to/ci-infra && bash scripts/setup.sh runner-kotoba
 ```
 
 The runner must be active before any PR is opened. PRs opened without an active runner
@@ -260,9 +260,9 @@ This repository is PR-first and feature-branch-only for agent work:
 - Keep changes isolated to one human-readable feature branch per task.
 - After pushing, open or update a PR to `develop` and link the relevant issue URL.
 - Every PR must include at least one explicit issue reference using a full URL
-  (example: `https://github.com/shikarii/kana-site/issues/1`).
+  (example: `https://github.com/shikarii/kotoba-lab/issues/1`).
 - Include a closing keyword plus issue URL when appropriate
-  (example: `Closes https://github.com/shikarii/kana-site/issues/1`).
+  (example: `Closes https://github.com/shikarii/kotoba-lab/issues/1`).
 - Do not close implementation issues until the PR is merged.
 
 ## 8. Human-Facing Wording for Issues and PRs
@@ -327,7 +327,7 @@ If a file grows past these limits, split it immediately — do not defer.
 
 ## 12. Kubernetes and Deployment
 
-Production target is a local Kubernetes cluster (minikube or k3s), namespace `kana`.
+Production target is a local Kubernetes cluster (minikube or k3s), namespace `kotoba`.
 
 Manifest layout:
 
@@ -353,8 +353,8 @@ Local development workflow:
 
 ```bash
 eval $(minikube docker-env)
-docker build -f docker/Dockerfile.client -t kana-client:local .
-docker build -f docker/Dockerfile.server -t kana-server:local .
+docker build -f docker/Dockerfile.client -t kotoba-client:local .
+docker build -f docker/Dockerfile.server -t kotoba-server:local .
 kubectl apply -f k8s/
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 ## Setup
 
 ```bash
-git clone https://github.com/shikarii/kana-site
-cd kana-site
+git clone https://github.com/shikarii/kotoba-lab
+cd kotoba-lab
 npm install
 npm run setup          # sync vendor assets and fetch SKK dictionary
 bash scripts/setup_hooks.sh   # install git hooks (one-time)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# kana-site
+# kotoba-lab
 
-[![Quality Gates](https://github.com/shikarii/kana-site/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/shikarii/kana-site/actions/workflows/quality-gates.yml)
-[![Deploy Pages](https://github.com/shikarii/kana-site/actions/workflows/deploy.yml/badge.svg)](https://github.com/shikarii/kana-site/actions/workflows/deploy.yml)
+[![Quality Gates](https://github.com/shikarii/kotoba-lab/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/shikarii/kotoba-lab/actions/workflows/quality-gates.yml)
+[![Deploy Pages](https://github.com/shikarii/kotoba-lab/actions/workflows/deploy.yml/badge.svg)](https://github.com/shikarii/kotoba-lab/actions/workflows/deploy.yml)
 
 Browser-based Japanese IME practice tool. Type romaji and get real-time hiragana/katakana
 conversion, kanji suggestions via SKK dictionary, furigana rendering, and text-to-speech.
 
-Live site: **https://shikarii.github.io/kana-site/**
+Live site: **https://shikarii.github.io/kotoba-lab/**
 
 ---
 
@@ -24,8 +24,8 @@ Live site: **https://shikarii.github.io/kana-site/**
 ## Getting started
 
 ```bash
-git clone https://github.com/shikarii/kana-site
-cd kana-site
+git clone https://github.com/shikarii/kotoba-lab
+cd kotoba-lab
 npm install
 npm run setup          # sync kuromoji/ipadic vendor assets and fetch SKK dictionary
 bash scripts/setup_hooks.sh   # install git hooks (one-time)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 Please do not open a public GitHub issue for security vulnerabilities.
 
 Report security issues directly to the maintainer via GitHub's private vulnerability
-reporting at https://github.com/shikarii/kana-site/security/advisories/new
+reporting at https://github.com/shikarii/kotoba-lab/security/advisories/new
 
 Include:
 

--- a/ci/dagger.json
+++ b/ci/dagger.json
@@ -1,5 +1,5 @@
 {
-  "name": "kana-ci",
+  "name": "kotoba-lab-ci",
   "sdk": "typescript",
   "source": "./",
   "engineVersion": "v0.15.3"

--- a/ci/package.json
+++ b/ci/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kana-ci",
+  "name": "kotoba-lab-ci",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/ci/src/index.ts
+++ b/ci/src/index.ts
@@ -15,16 +15,28 @@ import { dag, Directory, object, func } from "@dagger.io/dagger";
 @object()
 class KanaCi {
   /**
-   * Run client quality gates: prettier, eslint, typecheck, vitest, vite build.
+   * Run client quality gates: prettier, eslint, typecheck, vitest, vite build,
+   * and Playwright popup smoke tests.
    */
   @func()
   async clientQuality(source: Directory): Promise<string> {
     const npmCache = dag.cacheVolume("kana-npm-root");
+    const playwrightCache = dag.cacheVolume("kana-playwright");
 
     return dag
       .container()
       .from("node:24-slim")
+      // System deps required by Playwright's headless Chromium
+      .withExec(["apt-get", "update", "-qq"])
+      .withExec([
+        "apt-get", "install", "-y", "--no-install-recommends",
+        "libnss3", "libatk1.0-0", "libatk-bridge2.0-0", "libcups2",
+        "libdrm2", "libxkbcommon0", "libxcomposite1", "libxdamage1",
+        "libxfixes3", "libxrandr2", "libgbm1", "libasound2",
+        "libpangocairo-1.0-0", "libgtk-3-0", "libx11-xcb1",
+      ])
       .withMountedCache("/root/.npm", npmCache)
+      .withMountedCache("/root/.cache/ms-playwright", playwrightCache)
       .withMountedDirectory("/app", source)
       .withWorkdir("/app")
       .withExec(["npm", "ci"])
@@ -33,6 +45,8 @@ class KanaCi {
       .withExec(["npm", "run", "typecheck"])
       .withExec(["npm", "run", "test:run"])
       .withExec(["npm", "run", "build"])
+      .withExec(["npx", "playwright", "install", "chromium"])
+      .withExec(["npm", "run", "test:e2e"])
       .stdout();
   }
 

--- a/ci/src/index.ts
+++ b/ci/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * kana-site CI pipelines via Dagger.
+ * kotoba-lab CI pipelines via Dagger.
  *
  * Each function mirrors the equivalent quality-gates.yml job but runs inside
  * a container with persistent cache volumes — npm installs are only downloaded
@@ -20,8 +20,8 @@ class KanaCi {
    */
   @func()
   async clientQuality(source: Directory): Promise<string> {
-    const npmCache = dag.cacheVolume("kana-npm-root");
-    const playwrightCache = dag.cacheVolume("kana-playwright");
+    const npmCache = dag.cacheVolume("kotoba-npm-root");
+    const playwrightCache = dag.cacheVolume("kotoba-playwright");
 
     return dag
       .container()
@@ -56,7 +56,7 @@ class KanaCi {
    */
   @func()
   async serverQuality(source: Directory): Promise<string> {
-    const npmCache = dag.cacheVolume("kana-npm-server");
+    const npmCache = dag.cacheVolume("kotoba-npm-server");
 
     return dag
       .container()

--- a/ci/src/index.ts
+++ b/ci/src/index.ts
@@ -13,7 +13,7 @@
 import { dag, Directory, object, func } from "@dagger.io/dagger";
 
 @object()
-class KanaCi {
+class KotobaLabCi {
   /**
    * Run client quality gates: prettier, eslint, typecheck, vitest, vite build,
    * and Playwright popup smoke tests.

--- a/client/lib/cardStoreIdb.ts
+++ b/client/lib/cardStoreIdb.ts
@@ -30,7 +30,7 @@ interface IdbScheduling extends FsrsState {
   cardId: number;
 }
 
-const DB_NAME = 'kana-flashcards';
+const DB_NAME = 'kotoba-flashcards';
 const DB_VERSION = 1;
 
 async function openKanaDb(): Promise<IDBPDatabase> {

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,4 +1,56 @@
 services:
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  # One-shot model pull — run once with: docker compose --profile setup run --rm ollama-pull
+  ollama-pull:
+    image: ollama/ollama:latest
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    entrypoint: ["ollama", "pull", "qwen2.5:3b"]
+    restart: "no"
+    profiles: ["setup"]
+
+  server:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.server
+    ports:
+      - "3001:3001"
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      PORT: "3001"
+      DB_PATH: /data/kana.db
+      CORS_ORIGIN: "http://localhost"
+      OLLAMA_URL: "http://ollama:11434"
+      OLLAMA_MODEL: "qwen2.5:3b"
+    volumes:
+      - kana-data:/data
+    restart: unless-stopped
+
   client:
     build:
       context: ..
@@ -7,19 +59,8 @@ services:
       - "80:80"
     depends_on:
       - server
-
-  server:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile.server
-    ports:
-      - "3001:3001"
-    environment:
-      PORT: "3001"
-      DB_PATH: /data/kana.db
-      CORS_ORIGIN: "http://localhost"
-    volumes:
-      - kana-data:/data
+    restart: unless-stopped
 
 volumes:
   kana-data:
+  ollama-data:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -43,12 +43,12 @@ services:
         condition: service_healthy
     environment:
       PORT: "3001"
-      DB_PATH: /data/kana.db
+      DB_PATH: /data/kotoba.db
       CORS_ORIGIN: "http://localhost"
       OLLAMA_URL: "http://ollama:11434"
       OLLAMA_MODEL: "qwen2.5:3b"
     volumes:
-      - kana-data:/data
+      - kotoba-data:/data
     restart: unless-stopped
 
   client:
@@ -62,5 +62,5 @@ services:
     restart: unless-stopped
 
 volumes:
-  kana-data:
+  kotoba-data:
   ollama-data:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-kana-site is a browser-based Japanese IME (Input Method Editor) built with React,
+kotoba-lab is a browser-based Japanese IME (Input Method Editor) built with React,
 TypeScript, and Vite. It uses kuromoji for morphological analysis and an SKK dictionary
 for kanji conversion.
 

--- a/docs/browser-extension-scope.md
+++ b/docs/browser-extension-scope.md
@@ -1,8 +1,8 @@
 # Browser Extension: Furigana Sentence Collector — Scope
 
 A Chrome (MV3) extension that detects Japanese text on any webpage, injects
-furigana annotations via the local kana-site server, and lets users collect
-JP+EN sentence pairs directly into their kana-site database.
+furigana annotations via the local kotoba-lab server, and lets users collect
+JP+EN sentence pairs directly into their kotoba-lab database.
 
 ---
 
@@ -23,7 +23,7 @@ extension/
     index.tsx
   shared/
     parsePairs.ts        Shared copy of client/lib/reader.ts helpers
-    api.ts               Typed wrapper for kana-site REST API
+    api.ts               Typed wrapper for kotoba-lab REST API
   package.json
   vite.config.ts         @crxjs/vite-plugin (HMR-capable MV3 build)
   tsconfig.json
@@ -41,7 +41,7 @@ main client: `parsePairs`, `hasJapaneseChars`, `looksEnglish` are copied into
 **Goal**: collect selected text from any page and send it to the sentence DB.
 
 ### Features
-- **Context menu** — right-click any selection → "Add to kana-site"
+- **Context menu** — right-click any selection → "Add to kotoba-lab"
   - Uses the existing `POST /api/v1/sentences/import` endpoint
   - `source` field set to current tab URL
   - `parsePairs()` applied to selection: if JP + EN paragraph detected, both
@@ -179,7 +179,7 @@ curl -s -X POST http://localhost:3001/api/v1/annotate \
 
 # Manual: Load extension/dist/ as unpacked in Chrome
 # → Browse https://www3.nhk.or.jp/news/easy/
-# → Select a Japanese sentence, right-click → "Add to kana-site"
+# → Select a Japanese sentence, right-click → "Add to kotoba-lab"
 # → Open popup → sentence appears in last-imports list
 # → Phase 2: enable furigana overlay → ruby annotations appear on page
 ```

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,11 +1,11 @@
 browser.contextMenus.create({
-  id: 'kana-capture',
+  id: 'kotoba-capture',
   title: 'Add to Kana',
   contexts: ['selection'],
 });
 
 browser.contextMenus.onClicked.addListener(async (info, tab) => {
-  if (info.menuItemId !== 'kana-capture') return;
+  if (info.menuItemId !== 'kotoba-capture') return;
 
   const text = info.selectionText?.trim();
   if (!text) return;

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,15 @@
+browser.contextMenus.create({
+  id: 'kana-capture',
+  title: 'Add to Kana',
+  contexts: ['selection'],
+});
+
+browser.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId !== 'kana-capture') return;
+
+  const text = info.selectionText?.trim();
+  if (!text) return;
+
+  await browser.storage.session.set({ pendingText: text });
+  await browser.action.openPopup();
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Kana Capture",
+  "version": "0.1.0",
+  "description": "Select Japanese text on any page and save it as a flashcard in kana-site.",
+  "permissions": ["contextMenus", "storage", "activeTab"],
+  "host_permissions": [
+    "http://kana.local/*",
+    "http://localhost:3001/*"
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "action": {
+    "default_popup": "popup/popup.html",
+    "default_title": "Kana Capture"
+  },
+  "icons": {
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  }
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,10 +2,10 @@
   "manifest_version": 3,
   "name": "Kana Capture",
   "version": "0.1.0",
-  "description": "Select Japanese text on any page and save it as a flashcard in kana-site.",
+  "description": "Select Japanese text on any page and save it as a flashcard in kotoba-lab.",
   "permissions": ["contextMenus", "storage", "activeTab"],
   "host_permissions": [
-    "http://kana.local/*",
+    "http://kotoba.local/*",
     "http://localhost:3001/*"
   ],
   "background": {

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -1,0 +1,81 @@
+:root {
+  --bg:     #1e1c18;
+  --panel:  #252320;
+  --ink:    #e3dccf;
+  --muted:  #80786b;
+  --line:   #302d28;
+  --accent: #3a9570;
+  --accent-strong: #2d7a5e;
+  --danger: #c44e44;
+  font-size: 13px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  width: 320px;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: system-ui, sans-serif;
+}
+
+header {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--accent);
+}
+
+#app > section {
+  padding: 12px 14px;
+}
+
+.hidden { display: none; }
+
+.field { margin-bottom: 10px; }
+.field label {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--muted);
+  margin-bottom: 3px;
+}
+
+.japanese { font-size: 15px; line-height: 2; }
+.ruby-text ruby rt { font-size: 10px; color: var(--muted); }
+
+select {
+  width: 100%;
+  background: var(--panel);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 13px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+button {
+  flex: 1;
+  padding: 7px 0;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+}
+button.primary  { background: var(--accent-strong); color: #fff; }
+button.primary:disabled { opacity: .45; cursor: default; }
+button.secondary { background: var(--panel); color: var(--muted); border: 1px solid var(--line); }
+
+.muted  { color: var(--muted); font-size: 12px; }
+.danger { color: var(--danger); }
+.success { color: var(--accent); font-size: 14px; text-align: center; padding: 8px 0; }
+.model-tag { margin-top: 8px; text-align: right; }

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kana Capture</title>
+  <link rel="stylesheet" href="popup.css" />
+</head>
+<body>
+  <div id="app">
+    <header>
+      <span class="logo">Kana Capture</span>
+    </header>
+
+    <section id="loading" class="state">
+      <p class="muted">Enriching…</p>
+    </section>
+
+    <section id="result" class="state hidden">
+      <div class="field">
+        <label>Original</label>
+        <p id="original" class="japanese"></p>
+      </div>
+      <div class="field">
+        <label>Furigana</label>
+        <p id="furigana" class="japanese ruby-text"></p>
+      </div>
+      <div class="field">
+        <label>Translation</label>
+        <p id="translation"></p>
+      </div>
+      <div class="field">
+        <label>Deck</label>
+        <select id="deck-select">
+          <option value="">— loading decks —</option>
+        </select>
+      </div>
+      <div class="actions">
+        <button id="save-btn" class="primary" disabled>Save card</button>
+        <button id="cancel-btn" class="secondary">Cancel</button>
+      </div>
+      <p id="model-tag" class="muted model-tag"></p>
+    </section>
+
+    <section id="done" class="state hidden">
+      <p class="success">Card saved ✓</p>
+    </section>
+
+    <section id="error" class="state hidden">
+      <p id="error-msg" class="danger"></p>
+    </section>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,4 +1,4 @@
-const API_BASES = ['http://kana.local', 'http://localhost:3001'];
+const API_BASES = ['http://kotoba.local', 'http://localhost:3001'];
 
 async function apiBase() {
   for (const base of API_BASES) {
@@ -7,7 +7,7 @@ async function apiBase() {
       if (r.ok) return base;
     } catch { /* try next */ }
   }
-  throw new Error('kana-site server unreachable. Is it running?');
+  throw new Error('kotoba-lab server unreachable. Is it running?');
 }
 
 function show(id) {
@@ -59,7 +59,7 @@ async function main() {
   const sel = document.getElementById('deck-select');
   sel.innerHTML = '';
   if (decks.length === 0) {
-    sel.innerHTML = '<option value="">No decks — create one in kana-site first</option>';
+    sel.innerHTML = '<option value="">No decks — create one in kotoba-lab first</option>';
   } else {
     decks.forEach((d) => {
       const opt = document.createElement('option');

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,0 +1,94 @@
+const API_BASES = ['http://kana.local', 'http://localhost:3001'];
+
+async function apiBase() {
+  for (const base of API_BASES) {
+    try {
+      const r = await fetch(`${base}/health`, { signal: AbortSignal.timeout(1500) });
+      if (r.ok) return base;
+    } catch { /* try next */ }
+  }
+  throw new Error('kana-site server unreachable. Is it running?');
+}
+
+function show(id) {
+  ['loading', 'result', 'done', 'error'].forEach((s) => {
+    document.getElementById(s).classList.toggle('hidden', s !== id);
+  });
+}
+
+function setError(msg) {
+  document.getElementById('error-msg').textContent = msg;
+  show('error');
+}
+
+async function loadDecks(base) {
+  const res = await fetch(`${base}/api/v1/decks`);
+  if (!res.ok) throw new Error('Failed to load decks');
+  return res.json();
+}
+
+async function main() {
+  show('loading');
+
+  const { pendingText } = await browser.storage.session.get('pendingText');
+  if (!pendingText) { setError('No text captured. Select text then right-click → Add to Kana.'); return; }
+
+  let base;
+  try { base = await apiBase(); } catch (e) { setError(e.message); return; }
+
+  let enrichData;
+  try {
+    const res = await fetch(`${base}/api/v1/sentences/enrich`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: pendingText }),
+    });
+    if (!res.ok) throw new Error(`Enrich failed: ${res.status}`);
+    enrichData = await res.json();
+  } catch (e) { setError(e.message); return; }
+
+  document.getElementById('original').textContent = enrichData.original;
+  document.getElementById('furigana').innerHTML = enrichData.furigana;
+  document.getElementById('translation').textContent = enrichData.translation;
+  document.getElementById('model-tag').textContent =
+    `${enrichData.furiganaSource} · ${enrichData.translationModel}`;
+
+  let decks;
+  try { decks = await loadDecks(base); } catch { decks = []; }
+
+  const sel = document.getElementById('deck-select');
+  sel.innerHTML = '';
+  if (decks.length === 0) {
+    sel.innerHTML = '<option value="">No decks — create one in kana-site first</option>';
+  } else {
+    decks.forEach((d) => {
+      const opt = document.createElement('option');
+      opt.value = d.id;
+      opt.textContent = d.name;
+      sel.appendChild(opt);
+    });
+    document.getElementById('save-btn').disabled = false;
+  }
+
+  show('result');
+
+  document.getElementById('cancel-btn').onclick = () => window.close();
+
+  document.getElementById('save-btn').onclick = async () => {
+    const deckId = Number(sel.value);
+    if (!deckId) return;
+    try {
+      const res = await fetch(`${base}/api/v1/sentences/capture`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: pendingText, deckId }),
+      });
+      if (!res.ok) throw new Error(`Save failed: ${res.status}`);
+      await browser.storage.session.remove('pendingText');
+      show('done');
+      setTimeout(() => window.close(), 1500);
+    } catch (e) { setError(e.message); }
+  };
+}
+
+main();

--- a/extension/tampermonkey/kana-capture.user.js
+++ b/extension/tampermonkey/kana-capture.user.js
@@ -1,18 +1,18 @@
 // ==UserScript==
 // @name         Kana Capture
-// @namespace    http://kana.local/
+// @namespace    http://kotoba.local/
 // @version      0.1.0
 // @description  Select Japanese text on any page → enrich with furigana + translation via kana-site
 // @author       shikarii
 // @match        *://*/*
 // @grant        GM_xmlhttpRequest
-// @connect      kana.local
+// @connect      kotoba.local
 // ==/UserScript==
 
 (function () {
   'use strict';
 
-  const API_BASE = 'http://kana.local/api/v1/sentences';
+  const API_BASE = 'http://kotoba.local/api/v1/sentences';
   const JP_RE = /[\u3040-\u9FFF\uFF66-\uFF9F]/;
 
   let btn = null;
@@ -78,10 +78,10 @@
             const data = JSON.parse(res.responseText);
             showResult(data.furigana, data.translation, data.translationModel);
           } catch {
-            alert('[kana-capture] Failed to parse server response.');
+            alert('[kotoba-capture] Failed to parse server response.');
           }
         },
-        onerror: () => alert('[kana-capture] Could not reach kana.local — is the server running?'),
+        onerror: () => alert('[kotoba-capture] Could not reach kotoba.local — is the server running?'),
       });
     };
   });

--- a/extension/tampermonkey/kana-capture.user.js
+++ b/extension/tampermonkey/kana-capture.user.js
@@ -1,0 +1,89 @@
+// ==UserScript==
+// @name         Kana Capture
+// @namespace    http://kana.local/
+// @version      0.1.0
+// @description  Select Japanese text on any page → enrich with furigana + translation via kana-site
+// @author       shikarii
+// @match        *://*/*
+// @grant        GM_xmlhttpRequest
+// @connect      kana.local
+// @connect      localhost
+// ==/UserScript==
+
+(function () {
+  'use strict';
+
+  const API_BASE = 'http://kana.local/api/v1/sentences';
+  const JP_RE = /[\u3040-\u9FFF\uFF66-\uFF9F]/;
+
+  let btn = null;
+
+  function removeBtn() {
+    if (btn && btn.isConnected) btn.remove();
+    btn = null;
+  }
+
+  function showResult(furigana, translation, model) {
+    const overlay = document.createElement('div');
+    overlay.style.cssText = [
+      'position:fixed', 'bottom:16px', 'right:16px', 'z-index:2147483647',
+      'background:#1e1c18', 'color:#e3dccf', 'border:1px solid #302d28',
+      'border-radius:6px', 'padding:12px 14px', 'max-width:360px',
+      'font:13px/1.5 system-ui,sans-serif', 'box-shadow:0 4px 16px rgba(0,0,0,.5)',
+    ].join(';');
+
+    overlay.innerHTML = `
+      <div style="font-size:11px;color:#80786b;margin-bottom:4px">
+        furigana · <em>${model}</em>
+      </div>
+      <div style="margin-bottom:6px;line-height:1.8">${furigana}</div>
+      <div style="color:#3a9570">${translation}</div>
+      <div style="text-align:right;margin-top:8px">
+        <button id="kc-close" style="background:none;border:none;color:#80786b;cursor:pointer;font-size:12px">✕ close</button>
+      </div>`;
+
+    document.body.appendChild(overlay);
+    overlay.querySelector('#kc-close').onclick = () => overlay.remove();
+    setTimeout(() => overlay.isConnected && overlay.remove(), 12000);
+  }
+
+  document.addEventListener('mouseup', () => {
+    removeBtn();
+
+    const text = window.getSelection()?.toString().trim() ?? '';
+    if (!text || !JP_RE.test(text)) return;
+
+    btn = document.createElement('button');
+    btn.textContent = '+ Kana';
+    btn.style.cssText = [
+      'position:fixed', 'bottom:16px', 'right:16px', 'z-index:2147483647',
+      'padding:6px 14px', 'background:#2d7a5e', 'color:#fff',
+      'border:none', 'border-radius:4px', 'cursor:pointer',
+      'font:13px/1 system-ui,sans-serif', 'box-shadow:0 2px 8px rgba(0,0,0,.4)',
+    ].join(';');
+    document.body.appendChild(btn);
+
+    const autoRemove = setTimeout(removeBtn, 5000);
+
+    btn.onclick = () => {
+      clearTimeout(autoRemove);
+      removeBtn();
+
+      GM_xmlhttpRequest({
+        method: 'POST',
+        url: `${API_BASE}/enrich`,
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify({ text }),
+        onload: (res) => {
+          try {
+            const data = JSON.parse(res.responseText);
+            showResult(data.furigana, data.translation, data.translationModel);
+          } catch {
+            alert('[kana-capture] Failed to parse server response.');
+          }
+        },
+        onerror: () => alert('[kana-capture] Could not reach kana.local — is the server running?'),
+      });
+    };
+  });
+})();

--- a/extension/tampermonkey/kana-capture.user.js
+++ b/extension/tampermonkey/kana-capture.user.js
@@ -7,7 +7,6 @@
 // @match        *://*/*
 // @grant        GM_xmlhttpRequest
 // @connect      kana.local
-// @connect      localhost
 // ==/UserScript==
 
 (function () {

--- a/extension/tests/fixtures/test-page.html
+++ b/extension/tests/fixtures/test-page.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>Japanese Test Page</title>
+  <style>
+    body { font-family: serif; font-size: 18px; line-height: 2; padding: 2rem; }
+    p { margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <!-- Known sentences used in automated tests — do not change without updating popup.spec.ts -->
+  <article>
+    <p id="s1">日本語を勉強しています。</p>
+    <p id="s2">東京は日本の首都です。</p>
+    <p id="s3">毎朝コーヒーを飲みます。</p>
+    <p id="s4">この本はとても面白いです。</p>
+  </article>
+</body>
+</html>

--- a/extension/tests/popup.spec.ts
+++ b/extension/tests/popup.spec.ts
@@ -49,8 +49,8 @@ test.beforeEach(async ({ page }) => {
     window.close = () => {};
   }, PENDING_TEXT);
 
-  // Mock server calls — popup tries kana.local first, falls back to localhost:3001
-  for (const base of ['http://kana.local', 'http://localhost:3001']) {
+  // Mock server calls — popup tries kotoba.local first, falls back to localhost:3001
+  for (const base of ['http://kotoba.local', 'http://localhost:3001']) {
     await page.route(`${base}/health`, (route) =>
       route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
     );
@@ -140,7 +140,7 @@ test('clicking save transitions to done state', async ({ page }) => {
 test('save posts correct deckId to /capture', async ({ page }) => {
   let capturedBody: Record<string, unknown> | null = null;
 
-  await page.route('http://kana.local/api/v1/sentences/capture', async (route) => {
+  await page.route('http://kotoba.local/api/v1/sentences/capture', async (route) => {
     capturedBody = JSON.parse(route.request().postData() ?? '{}') as Record<string, unknown>;
     await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(MOCK_CAPTURE) });
   });
@@ -162,7 +162,7 @@ test('save posts correct deckId to /capture', async ({ page }) => {
 
 test('shows error state when server is unreachable', async ({ page }) => {
   // Override health checks to fail so apiBase() throws
-  for (const base of ['http://kana.local', 'http://localhost:3001']) {
+  for (const base of ['http://kotoba.local', 'http://localhost:3001']) {
     await page.route(`${base}/health`, (route) => route.abort());
   }
 

--- a/extension/tests/popup.spec.ts
+++ b/extension/tests/popup.spec.ts
@@ -1,0 +1,191 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const POPUP_URL = `file://${path.resolve(__dirname, '../popup/popup.html')}`;
+
+const PENDING_TEXT = '日本語を勉強しています';
+
+const MOCK_ENRICH = {
+  original: PENDING_TEXT,
+  furigana:
+    '<ruby>日本語<rt>にほんご</rt></ruby>を<ruby>勉強<rt>べんきょう</rt></ruby>しています',
+  translation: 'I am studying Japanese.',
+  translationModel: 'qwen2.5:3b',
+  furiganaSource: 'kuroshiro',
+};
+
+const MOCK_DECKS = [
+  { id: 1, name: 'Core Vocab', description: '', createdAt: 1_000_000 },
+  { id: 2, name: 'Grammar', description: '', createdAt: 1_000_001 },
+];
+
+const MOCK_CAPTURE = {
+  card: {
+    id: 42,
+    deckId: 1,
+    front: PENDING_TEXT,
+    back: MOCK_ENRICH.translation,
+    createdAt: 1_000_002,
+  },
+  ...MOCK_ENRICH,
+};
+
+test.beforeEach(async ({ page }) => {
+  // Inject browser WebExtension API mock before popup.js runs
+  await page.addInitScript((text: string) => {
+    (window as unknown as Record<string, unknown>)['browser'] = {
+      storage: {
+        session: {
+          get: (_key: string) => Promise.resolve({ pendingText: text }),
+          remove: (_key: string) => Promise.resolve(),
+        },
+      },
+    };
+    // Prevent window.close() from terminating the page during assertions
+    window.close = () => {};
+  }, PENDING_TEXT);
+
+  // Mock server calls — popup tries kana.local first, falls back to localhost:3001
+  for (const base of ['http://kana.local', 'http://localhost:3001']) {
+    await page.route(`${base}/health`, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' }),
+    );
+    await page.route(`${base}/api/v1/sentences/enrich`, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_ENRICH) }),
+    );
+    await page.route(`${base}/api/v1/decks`, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_DECKS) }),
+    );
+    await page.route(`${base}/api/v1/sentences/capture`, (route) =>
+      route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(MOCK_CAPTURE) }),
+    );
+  }
+});
+
+// ── Loading → Result transition ───────────────────────────────────────────────
+
+test('shows loading state then transitions to result', async ({ page }) => {
+  await page.goto(POPUP_URL);
+  // Loading section must disappear and result must appear
+  await expect(page.locator('#result')).not.toHaveClass(/hidden/, { timeout: 5000 });
+  await expect(page.locator('#loading')).toHaveClass(/hidden/);
+});
+
+// ── Enrich response shape ─────────────────────────────────────────────────────
+
+test('renders original Japanese text', async ({ page }) => {
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#result')).not.toHaveClass(/hidden/, { timeout: 5000 });
+  await expect(page.locator('#original')).toHaveText(PENDING_TEXT);
+});
+
+test('renders furigana as ruby elements', async ({ page }) => {
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#result')).not.toHaveClass(/hidden/, { timeout: 5000 });
+
+  const rubyCount = await page.locator('#furigana ruby').count();
+  expect(rubyCount).toBeGreaterThan(0);
+
+  const firstRt = page.locator('#furigana ruby rt').first();
+  await expect(firstRt).toHaveText('にほんご');
+});
+
+test('renders translation text', async ({ page }) => {
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#result')).not.toHaveClass(/hidden/, { timeout: 5000 });
+  await expect(page.locator('#translation')).toHaveText(MOCK_ENRICH.translation);
+});
+
+test('shows model provenance tag', async ({ page }) => {
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#result')).not.toHaveClass(/hidden/, { timeout: 5000 });
+  await expect(page.locator('#model-tag')).toContainText('qwen2.5:3b');
+  await expect(page.locator('#model-tag')).toContainText('kuroshiro');
+});
+
+// ── Deck picker ───────────────────────────────────────────────────────────────
+
+test('populates deck dropdown with all decks', async ({ page }) => {
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#result')).not.toHaveClass(/hidden/, { timeout: 5000 });
+
+  const options = page.locator('#deck-select option');
+  await expect(options).toHaveCount(MOCK_DECKS.length);
+  await expect(options.nth(0)).toHaveText('Core Vocab');
+  await expect(options.nth(1)).toHaveText('Grammar');
+});
+
+test('save button is enabled when decks are loaded', async ({ page }) => {
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#result')).not.toHaveClass(/hidden/, { timeout: 5000 });
+  await expect(page.locator('#save-btn')).toBeEnabled();
+});
+
+// ── Save flow ─────────────────────────────────────────────────────────────────
+
+test('clicking save transitions to done state', async ({ page }) => {
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#save-btn')).toBeEnabled({ timeout: 5000 });
+
+  await page.locator('#save-btn').click();
+
+  await expect(page.locator('#done')).not.toHaveClass(/hidden/, { timeout: 5000 });
+  await expect(page.locator('#done')).toContainText('Card saved');
+});
+
+test('save posts correct deckId to /capture', async ({ page }) => {
+  let capturedBody: Record<string, unknown> | null = null;
+
+  await page.route('http://kana.local/api/v1/sentences/capture', async (route) => {
+    capturedBody = JSON.parse(route.request().postData() ?? '{}') as Record<string, unknown>;
+    await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(MOCK_CAPTURE) });
+  });
+
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#save-btn')).toBeEnabled({ timeout: 5000 });
+
+  // Select the second deck
+  await page.locator('#deck-select').selectOption({ index: 1 });
+  await page.locator('#save-btn').click();
+
+  await expect(page.locator('#done')).not.toHaveClass(/hidden/, { timeout: 5000 });
+  expect(capturedBody).not.toBeNull();
+  expect(capturedBody!['text']).toBe(PENDING_TEXT);
+  expect(capturedBody!['deckId']).toBe(MOCK_DECKS[1].id);
+});
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+test('shows error state when server is unreachable', async ({ page }) => {
+  // Override health checks to fail so apiBase() throws
+  for (const base of ['http://kana.local', 'http://localhost:3001']) {
+    await page.route(`${base}/health`, (route) => route.abort());
+  }
+
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#error')).not.toHaveClass(/hidden/, { timeout: 8000 });
+  await expect(page.locator('#error-msg')).toContainText('unreachable');
+});
+
+test('shows error when no pending text is set', async ({ page }) => {
+  // Override browser mock to return no pending text
+  await page.addInitScript(() => {
+    (window as unknown as Record<string, unknown>)['browser'] = {
+      storage: {
+        session: {
+          get: () => Promise.resolve({}),
+          remove: () => Promise.resolve(),
+        },
+      },
+    };
+    window.close = () => {};
+  });
+
+  await page.goto(POPUP_URL);
+  await expect(page.locator('#error')).not.toHaveClass(/hidden/, { timeout: 5000 });
+  await expect(page.locator('#error-msg')).toContainText('No text captured');
+});

--- a/helm/ollama/values.yaml
+++ b/helm/ollama/values.yaml
@@ -1,0 +1,23 @@
+ollama:
+  models:
+    - qwen2.5:3b
+  gpu:
+    enabled: true
+    type: nvidia
+    number: 1
+
+resources:
+  requests:
+    memory: "2Gi"
+  limits:
+    memory: "4Gi"
+    nvidia.com/gpu: 1
+
+service:
+  type: ClusterIP
+  port: 11434
+
+# Persist downloaded models across pod restarts
+persistentVolume:
+  enabled: true
+  size: 4Gi

--- a/helm/ollama/values.yaml
+++ b/helm/ollama/values.yaml
@@ -7,17 +7,27 @@ ollama:
     number: 1
 
 resources:
-  requests:
-    memory: "2Gi"
   limits:
     memory: "4Gi"
-    nvidia.com/gpu: 1
+    nvidia.com/gpu: "1"
+  requests:
+    memory: "2Gi"
+
+persistentVolume:
+  enabled: true
+  size: 4Gi
+  storageClass: ""
 
 service:
   type: ClusterIP
   port: 11434
 
-# Persist downloaded models across pod restarts
-persistentVolume:
+livenessProbe:
   enabled: true
-  size: 4Gi
+  initialDelaySeconds: 60
+  periodSeconds: 30
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10

--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kana-client
-  namespace: kana
+  name: kotoba-client
+  namespace: kotoba
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: kana-client
+      app: kotoba-client
   template:
     metadata:
       labels:
-        app: kana-client
+        app: kotoba-client
     spec:
       containers:
         - name: client
-          image: kana-client:local
+          image: kotoba-client:local
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/k8s/client-service.yaml
+++ b/k8s/client-service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kana-client
-  namespace: kana
+  name: kotoba-client
+  namespace: kotoba
 spec:
   selector:
-    app: kana-client
+    app: kotoba-client
   ports:
     - port: 80
       targetPort: 80

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -5,4 +5,6 @@ metadata:
   namespace: kana
 data:
   PORT: "3001"
-  CORS_ORIGIN: "http://localhost"
+  CORS_ORIGIN: "http://kana.local"
+  OLLAMA_URL: "http://ollama.kana.svc.cluster.local:11434"
+  OLLAMA_MODEL: "qwen2.5:3b"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kana-config
-  namespace: kana
+  name: kotoba-config
+  namespace: kotoba
 data:
   PORT: "3001"
-  CORS_ORIGIN: "http://kana.local"
-  OLLAMA_URL: "http://ollama.kana.svc.cluster.local:11434"
+  CORS_ORIGIN: "http://kotoba.local"
+  OLLAMA_URL: "http://ollama.kotoba.svc.cluster.local:11434"
   OLLAMA_MODEL: "qwen2.5:3b"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,8 +1,8 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: kana-ingress
-  namespace: kana
+  name: kotoba-ingress
+  namespace: kotoba
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
@@ -14,13 +14,13 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: kana-server
+                name: kotoba-server
                 port:
                   number: 3001
           - path: /()(.*)
             pathType: ImplementationSpecific
             backend:
               service:
-                name: kana-client
+                name: kotoba-client
                 port:
                   number: 80

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kana
+  name: kotoba

--- a/k8s/pvc.yaml
+++ b/k8s/pvc.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: kana-data
-  namespace: kana
+  name: kotoba-data
+  namespace: kotoba
 spec:
   accessModes:
     - ReadWriteOnce

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -4,8 +4,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kana-secret
-  namespace: kana
+  name: kotoba-secret
+  namespace: kotoba
 type: Opaque
 stringData:
-  DB_PATH: /data/kana.db
+  DB_PATH: /data/kotoba.db

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,33 +1,33 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kana-server
-  namespace: kana
+  name: kotoba-server
+  namespace: kotoba
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kana-server
+      app: kotoba-server
   template:
     metadata:
       labels:
-        app: kana-server
+        app: kotoba-server
     spec:
       containers:
         - name: server
-          image: kana-server:local
+          image: kotoba-server:local
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3001
           envFrom:
             - configMapRef:
-                name: kana-config
+                name: kotoba-config
             - secretRef:
-                name: kana-secret
+                name: kotoba-secret
           volumeMounts:
             - name: data
               mountPath: /data
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: kana-data
+            claimName: kotoba-data

--- a/k8s/server-service.yaml
+++ b/k8s/server-service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kana-server
-  namespace: kana
+  name: kotoba-server
+  namespace: kotoba
 spec:
   selector:
-    app: kana-server
+    app: kotoba-server
   ports:
     - port: 3001
       targetPort: 3001

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "wanakana": "^5.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.50.0",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.2",
         "@testing-library/user-event": "^14.5.2",
@@ -1153,6 +1154,22 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1667,7 +1684,6 @@
       "integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5137,6 +5153,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:check": "eslint \"client/**/*.{ts,tsx}\"",
     "test": "vitest",
     "test:run": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "fflate": "^0.8.2",
@@ -49,6 +50,7 @@
     "shx": "^0.4.0",
     "typescript": "^5.6.3",
     "vite": "^5.0.0",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "@playwright/test": "^1.50.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kana-kanji-ime",
+  "name": "kotoba-lab",
   "version": "1.0.0",
   "description": "Browser Japanese IME using kuromoji + SKK dictionary",
   "type": "module",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './extension/tests',
+  fullyParallel: true,
+  retries: 0,
+  reporter: 'line',
+  use: {
+    headless: true,
+    // Intercept fetch from file:// pages
+    bypassCSP: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Bootstrap kana-site local stack: k3d + nginx-ingress + Ollama (qwen2.5:3b) + kana-site.
+# Prerequisites: k3d, kubectl, helm
+set -euo pipefail
+
+CLUSTER=kana
+NAMESPACE=kana
+MODEL=qwen2.5:3b
+
+# ── 1. k3d cluster ────────────────────────────────────────────────────────────
+if k3d cluster list | grep -q "^${CLUSTER}"; then
+  echo "[k3d] cluster '${CLUSTER}' already exists, skipping create"
+else
+  echo "[k3d] creating cluster '${CLUSTER}'"
+  k3d cluster create "${CLUSTER}" \
+    --agents 1 \
+    --k3s-arg '--disable=traefik@server:*' \
+    -p "80:80@loadbalancer"
+fi
+
+# ── 2. nginx ingress controller ───────────────────────────────────────────────
+echo "[helm] installing nginx ingress controller"
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx 2>/dev/null || true
+helm repo update
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --create-namespace \
+  --set controller.service.type=NodePort \
+  --wait --timeout 120s
+
+# ── 3. Ollama ─────────────────────────────────────────────────────────────────
+echo "[helm] installing Ollama"
+helm repo add ollama-helm https://otwld.github.io/ollama-helm/ 2>/dev/null || true
+helm repo update
+helm upgrade --install ollama ollama-helm/ollama \
+  --namespace "${NAMESPACE}" --create-namespace \
+  -f helm/ollama/values.yaml \
+  --wait --timeout 180s
+
+echo "[ollama] pulling model ${MODEL} (first run may take a few minutes)"
+kubectl exec -n "${NAMESPACE}" deploy/ollama -- ollama pull "${MODEL}"
+
+# ── 4. kana-site manifests ────────────────────────────────────────────────────
+echo "[kubectl] applying kana-site manifests"
+kubectl apply -f k8s/
+
+# ── 5. /etc/hosts ─────────────────────────────────────────────────────────────
+if grep -q "kana.local" /etc/hosts; then
+  echo "[hosts] kana.local already present"
+else
+  echo "[hosts] adding kana.local → 127.0.0.1"
+  echo "127.0.0.1  kana.local" | sudo tee -a /etc/hosts
+fi
+
+echo ""
+echo "✓ kana-site: http://kana.local"
+echo "✓ API:       http://kana.local/api/v1/sentences/enrich"
+echo "✓ Ollama:    http://ollama.${NAMESPACE}.svc.cluster.local:11434 (cluster-internal)"

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# Bootstrap kana-site local stack: k3d + nginx-ingress + Ollama (qwen2.5:3b) + kana-site.
-# Prerequisites: k3d, kubectl, helm
+# Bootstrap kana-site local stack: k3d cluster + nginx ingress + Ollama (qwen2.5:3b) + kana-site.
+#
+# Prerequisites (install once):
+#   winget install k3d Kubernetes.kubectl Helm.Helm
+#
+# Usage:
+#   bash scripts/setup-local.sh
 set -euo pipefail
 
 CLUSTER=kana
@@ -8,7 +13,7 @@ NAMESPACE=kana
 MODEL=qwen2.5:3b
 
 # ── 1. k3d cluster ────────────────────────────────────────────────────────────
-if k3d cluster list | grep -q "^${CLUSTER}"; then
+if k3d cluster list 2>/dev/null | grep -q "^${CLUSTER}"; then
   echo "[k3d] cluster '${CLUSTER}' already exists, skipping create"
 else
   echo "[k3d] creating cluster '${CLUSTER}'"
@@ -21,7 +26,7 @@ fi
 # ── 2. nginx ingress controller ───────────────────────────────────────────────
 echo "[helm] installing nginx ingress controller"
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx 2>/dev/null || true
-helm repo update
+helm repo update ingress-nginx
 helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx --create-namespace \
   --set controller.service.type=NodePort \
@@ -30,28 +35,42 @@ helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
 # ── 3. Ollama ─────────────────────────────────────────────────────────────────
 echo "[helm] installing Ollama"
 helm repo add ollama-helm https://otwld.github.io/ollama-helm/ 2>/dev/null || true
-helm repo update
+helm repo update ollama-helm
 helm upgrade --install ollama ollama-helm/ollama \
   --namespace "${NAMESPACE}" --create-namespace \
   -f helm/ollama/values.yaml \
-  --wait --timeout 180s
+  --wait --timeout 300s
 
-echo "[ollama] pulling model ${MODEL} (first run may take a few minutes)"
+echo "[ollama] pulling model ${MODEL} (first run: ~2 GB download)"
 kubectl exec -n "${NAMESPACE}" deploy/ollama -- ollama pull "${MODEL}"
 
-# ── 4. kana-site manifests ────────────────────────────────────────────────────
+# ── 4. Build + import kana images ────────────────────────────────────────────
+echo "[docker] building kana-server:local"
+docker build -t kana-server:local -f docker/Dockerfile.server .
+
+echo "[docker] building kana-client:local"
+docker build -t kana-client:local -f docker/Dockerfile.client .
+
+echo "[k3d] importing images into cluster '${CLUSTER}'"
+k3d image import kana-server:local kana-client:local -c "${CLUSTER}"
+
+# ── 5. kana-site manifests ────────────────────────────────────────────────────
 echo "[kubectl] applying kana-site manifests"
 kubectl apply -f k8s/
 
-# ── 5. /etc/hosts ─────────────────────────────────────────────────────────────
-if grep -q "kana.local" /etc/hosts; then
+# ── 6. /etc/hosts ─────────────────────────────────────────────────────────────
+if grep -q "kana.local" /etc/hosts 2>/dev/null; then
   echo "[hosts] kana.local already present"
 else
-  echo "[hosts] adding kana.local → 127.0.0.1"
+  echo "[hosts] adding 127.0.0.1  kana.local — may prompt for sudo password"
   echo "127.0.0.1  kana.local" | sudo tee -a /etc/hosts
 fi
 
+# ── Done ──────────────────────────────────────────────────────────────────────
 echo ""
-echo "✓ kana-site: http://kana.local"
-echo "✓ API:       http://kana.local/api/v1/sentences/enrich"
-echo "✓ Ollama:    http://ollama.${NAMESPACE}.svc.cluster.local:11434 (cluster-internal)"
+echo "✓ kana-site:  http://kana.local"
+echo "✓ API:        http://kana.local/api/v1/sentences/enrich"
+echo "✓ Ollama:     ollama.${NAMESPACE}.svc.cluster.local:11434 (cluster-internal)"
+echo ""
+echo "Tampermonkey script is ready — install extension/tampermonkey/kana-capture.user.js"
+echo "Select any Japanese text on a page and click '+ Kana'"

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bootstrap kana-site local stack: k3d cluster + nginx ingress + Ollama (qwen2.5:3b) + kana-site.
+# Bootstrap kotoba-lab local stack: k3d cluster + nginx ingress + Ollama (qwen2.5:3b) + kotoba-lab.
 #
 # Prerequisites (install once):
 #   winget install k3d Kubernetes.kubectl Helm.Helm
@@ -8,8 +8,8 @@
 #   bash scripts/setup-local.sh
 set -euo pipefail
 
-CLUSTER=kana
-NAMESPACE=kana
+CLUSTER=kotoba
+NAMESPACE=kotoba
 MODEL=qwen2.5:3b
 
 # ── 1. k3d cluster ────────────────────────────────────────────────────────────
@@ -44,33 +44,33 @@ helm upgrade --install ollama ollama-helm/ollama \
 echo "[ollama] pulling model ${MODEL} (first run: ~2 GB download)"
 kubectl exec -n "${NAMESPACE}" deploy/ollama -- ollama pull "${MODEL}"
 
-# ── 4. Build + import kana images ────────────────────────────────────────────
-echo "[docker] building kana-server:local"
-docker build -t kana-server:local -f docker/Dockerfile.server .
+# ── 4. Build + import kotoba images ────────────────────────────────────────────
+echo "[docker] building kotoba-server:local"
+docker build -t kotoba-server:local -f docker/Dockerfile.server .
 
-echo "[docker] building kana-client:local"
-docker build -t kana-client:local -f docker/Dockerfile.client .
+echo "[docker] building kotoba-client:local"
+docker build -t kotoba-client:local -f docker/Dockerfile.client .
 
 echo "[k3d] importing images into cluster '${CLUSTER}'"
-k3d image import kana-server:local kana-client:local -c "${CLUSTER}"
+k3d image import kotoba-server:local kotoba-client:local -c "${CLUSTER}"
 
-# ── 5. kana-site manifests ────────────────────────────────────────────────────
-echo "[kubectl] applying kana-site manifests"
+# ── 5. kotoba-lab manifests ────────────────────────────────────────────────────
+echo "[kubectl] applying kotoba-lab manifests"
 kubectl apply -f k8s/
 
 # ── 6. /etc/hosts ─────────────────────────────────────────────────────────────
-if grep -q "kana.local" /etc/hosts 2>/dev/null; then
-  echo "[hosts] kana.local already present"
+if grep -q "kotoba.local" /etc/hosts 2>/dev/null; then
+  echo "[hosts] kotoba.local already present"
 else
-  echo "[hosts] adding 127.0.0.1  kana.local — may prompt for sudo password"
-  echo "127.0.0.1  kana.local" | sudo tee -a /etc/hosts
+  echo "[hosts] adding 127.0.0.1  kotoba.local — may prompt for sudo password"
+  echo "127.0.0.1  kotoba.local" | sudo tee -a /etc/hosts
 fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 echo ""
-echo "✓ kana-site:  http://kana.local"
-echo "✓ API:        http://kana.local/api/v1/sentences/enrich"
+echo "✓ kotoba-lab:  http://kotoba.local"
+echo "✓ API:        http://kotoba.local/api/v1/sentences/enrich"
 echo "✓ Ollama:     ollama.${NAMESPACE}.svc.cluster.local:11434 (cluster-internal)"
 echo ""
-echo "Tampermonkey script is ready — install extension/tampermonkey/kana-capture.user.js"
+echo "Tampermonkey script is ready — install extension/tampermonkey/kotoba-capture.user.js"
 echo "Select any Japanese text on a page and click '+ Kana'"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "kana-site-server",
+  "name": "kotoba-lab-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kana-site-server",
+      "name": "kotoba-lab-server",
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,8 @@
         "better-sqlite3": "^11.7.0",
         "drizzle-orm": "^0.38.3",
         "hono": "^4.6.17",
+        "kuroshiro": "^1.2.0",
+        "kuroshiro-analyzer-kuromoji": "^1.1.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -23,6 +25,15 @@
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
         "vitest": "^3.0.4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1036,6 +1047,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1215,6 +1235,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/doublearray": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "license": "MIT"
     },
     "node_modules/drizzle-orm": {
       "version": "0.38.4",
@@ -1539,6 +1565,44 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kuromoji": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+      "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^2.0.1",
+        "doublearray": "0.0.2",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/kuroshiro": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/kuroshiro/-/kuroshiro-1.2.0.tgz",
+      "integrity": "sha512-yBGCK9oDOY3LGZ/KXaN9m7ADcAuSczOR2FoMRYwHLUlis3/o/uxdMVROAjENFO0NQJgALhIdWxI/vIBVrMCk9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      }
+    },
+    "node_modules/kuroshiro-analyzer-kuromoji": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/kuroshiro-analyzer-kuromoji/-/kuroshiro-analyzer-kuromoji-1.1.0.tgz",
+      "integrity": "sha512-BSJFhpsQdPwfFLfjKxfLA9iL+/PC6LCR9vgwgb5Jc7jZwk9ilX8SAV6CwhAQZY611tiuhbB52ONYKDO8hgY1bA==",
+      "license": "MIT",
+      "dependencies": {
+        "kuromoji": "^0.1.1"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -2308,6 +2372,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kana-site-server",
+  "name": "kotoba-lab-server",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,8 @@
     "@hono/node-server": "^1.13.7",
     "@hono/zod-validator": "^0.4.3",
     "adm-zip": "^0.5.16",
+    "kuroshiro": "^1.2.0",
+    "kuroshiro-analyzer-kuromoji": "^1.1.0",
     "better-sqlite3": "^11.7.0",
     "drizzle-orm": "^0.38.3",
     "hono": "^4.6.17",

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -4,6 +4,8 @@ const EnvSchema = z.object({
   PORT: z.coerce.number().int().min(1).max(65535).default(3001),
   DB_PATH: z.string().default('./dev.db'),
   CORS_ORIGIN: z.string().default('http://localhost:5173'),
+  OLLAMA_URL: z.string().default('http://ollama:11434'),
+  OLLAMA_MODEL: z.string().default('qwen2.5:3b'),
 });
 
 export type Config = z.infer<typeof EnvSchema>;

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -32,6 +32,9 @@ export const cards = sqliteTable('cards', {
   front: text('front').notNull(),
   back: text('back').notNull(),
   createdAt: integer('created_at').notNull().default(sql`(unixepoch())`),
+  translationModel: text('translation_model'),
+  furiganaSource: text('furigana_source'),
+  enrichedAt: integer('enriched_at'),
 });
 
 export type CardRow = typeof cards.$inferSelect;

--- a/server/src/db/setup.ts
+++ b/server/src/db/setup.ts
@@ -74,4 +74,17 @@ export function setupDatabase() {
       scheduled_days INTEGER NOT NULL
     );
   `);
+
+  // Additive migrations — no-ops if columns already exist
+  for (const col of [
+    'ALTER TABLE cards ADD COLUMN translation_model TEXT',
+    'ALTER TABLE cards ADD COLUMN furigana_source TEXT',
+    'ALTER TABLE cards ADD COLUMN enriched_at INTEGER',
+  ]) {
+    try {
+      db.exec(col);
+    } catch {
+      // column already exists
+    }
+  }
 }

--- a/server/src/routes/enrich.ts
+++ b/server/src/routes/enrich.ts
@@ -1,0 +1,88 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { getConfig } from '../config/env';
+import { getDb } from '../db/client';
+import { cards, cardScheduling } from '../db/schema';
+import { newFsrsState } from '../services/fsrsService';
+import { toCard } from '../services/deckService';
+import { getFurigana, getTranslation } from '../services/enrichService';
+
+export const enrichRoutes = new Hono();
+
+const enrichSchema = z.object({
+  text: z.string().min(1).max(1000),
+});
+
+const captureSchema = z.object({
+  text: z.string().min(1).max(1000),
+  deckId: z.number().int().positive(),
+});
+
+enrichRoutes.post('/enrich', zValidator('json', enrichSchema), async (c) => {
+  const { text } = c.req.valid('json');
+  const { OLLAMA_URL, OLLAMA_MODEL } = getConfig();
+
+  const [furigana, translation] = await Promise.all([
+    getFurigana(text),
+    getTranslation(text, OLLAMA_URL, OLLAMA_MODEL),
+  ]);
+
+  return c.json({
+    original: text,
+    furigana,
+    translation,
+    translationModel: OLLAMA_MODEL,
+    furiganaSource: 'kuroshiro',
+  });
+});
+
+enrichRoutes.post('/capture', zValidator('json', captureSchema), async (c) => {
+  const { text, deckId } = c.req.valid('json');
+  const { OLLAMA_URL, OLLAMA_MODEL } = getConfig();
+
+  const [furigana, translation] = await Promise.all([
+    getFurigana(text),
+    getTranslation(text, OLLAMA_URL, OLLAMA_MODEL),
+  ]);
+
+  const db = getDb();
+  const card = db
+    .insert(cards)
+    .values({
+      deckId,
+      front: text,
+      back: translation,
+      createdAt: Math.floor(Date.now() / 1000),
+      translationModel: OLLAMA_MODEL,
+      furiganaSource: 'kuroshiro',
+      enrichedAt: Date.now(),
+    })
+    .returning()
+    .get();
+
+  const fsrs = newFsrsState(Date.now());
+  db.insert(cardScheduling)
+    .values({
+      cardId: card.id,
+      stability: fsrs.stability,
+      difficulty: fsrs.difficulty,
+      elapsedDays: fsrs.elapsedDays,
+      scheduledDays: fsrs.scheduledDays,
+      reps: fsrs.reps,
+      lapses: fsrs.lapses,
+      state: fsrs.state,
+      dueAt: fsrs.dueAt,
+      lastReviewAt: fsrs.lastReviewAt,
+    })
+    .run();
+
+  return c.json({
+    card: toCard(card),
+    original: text,
+    furigana,
+    translation,
+    translationModel: OLLAMA_MODEL,
+    furiganaSource: 'kuroshiro',
+  }, 201);
+});

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -4,6 +4,7 @@ import { logger as honoLogger } from 'hono/logger';
 import { getConfig } from '../config/env';
 import { sentenceRoutes } from './sentences';
 import { deckRoutes } from './decks';
+import { enrichRoutes } from './enrich';
 
 const config = getConfig();
 
@@ -15,4 +16,5 @@ app.use('*', honoLogger());
 app.get('/health', (c) => c.json({ ok: true }));
 
 app.route('/api/v1/sentences', sentenceRoutes);
+app.route('/api/v1/sentences', enrichRoutes);
 app.route('/api/v1/decks', deckRoutes);

--- a/server/src/routes/types.ts
+++ b/server/src/routes/types.ts
@@ -1,4 +1,4 @@
-/** Shared request/response types for the kana-site API.
+/** Shared request/response types for the kotoba-lab API.
  *  Mirror this file manually in client/types/api.ts for the frontend.
  *  The frontend must never import from server/. */
 

--- a/server/src/routes/types.ts
+++ b/server/src/routes/types.ts
@@ -101,3 +101,26 @@ export interface AnkiImportResponse {
   imported: number;
   skipped: number;
 }
+
+// ─── Sentence enrichment ──────────────────────────────────────────────────────
+
+export interface EnrichRequest {
+  text: string;
+}
+
+export interface EnrichResponse {
+  original: string;
+  furigana: string;          // HTML ruby string
+  translation: string;
+  translationModel: string;  // e.g. 'qwen2.5:3b'
+  furiganaSource: string;    // e.g. 'kuroshiro'
+}
+
+export interface CaptureRequest {
+  text: string;
+  deckId: number;
+}
+
+export interface CaptureResponse extends EnrichResponse {
+  card: Card;
+}

--- a/server/src/services/enrichService.ts
+++ b/server/src/services/enrichService.ts
@@ -1,0 +1,35 @@
+import Kuroshiro from 'kuroshiro';
+import KuromojiAnalyzer from 'kuroshiro-analyzer-kuromoji';
+
+let _kuroshiro: Kuroshiro | null = null;
+
+async function getKuroshiro(): Promise<Kuroshiro> {
+  if (_kuroshiro) return _kuroshiro;
+  _kuroshiro = new Kuroshiro();
+  await _kuroshiro.init(new KuromojiAnalyzer());
+  return _kuroshiro;
+}
+
+export async function getFurigana(text: string): Promise<string> {
+  const k = await getKuroshiro();
+  return k.convert(text, { mode: 'furigana', to: 'hiragana' });
+}
+
+export async function getTranslation(
+  text: string,
+  ollamaUrl: string,
+  model: string,
+): Promise<string> {
+  const res = await fetch(`${ollamaUrl}/api/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model,
+      prompt: `Translate this Japanese sentence to natural English. Reply with only the translation, no explanation.\n\n${text}`,
+      stream: false,
+    }),
+  });
+  if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
+  const json = (await res.json()) as { response: string };
+  return json.response.trim();
+}

--- a/server/src/types/kuroshiro.d.ts
+++ b/server/src/types/kuroshiro.d.ts
@@ -1,0 +1,23 @@
+declare module 'kuroshiro' {
+  interface ConvertOptions {
+    mode?: 'normal' | 'spaced' | 'okurigana' | 'furigana';
+    to?: 'hiragana' | 'katakana' | 'romaji';
+    romajiSystem?: 'nippon' | 'passport' | 'hepburn';
+    delimiter_start?: string;
+    delimiter_end?: string;
+  }
+
+  class Kuroshiro {
+    init(analyzer: unknown): Promise<void>;
+    convert(str: string, options?: ConvertOptions): Promise<string>;
+  }
+
+  export = Kuroshiro;
+}
+
+declare module 'kuroshiro-analyzer-kuromoji' {
+  class KuromojiAnalyzer {
+    constructor(options?: { dictPath?: string });
+  }
+  export = KuromojiAnalyzer;
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,14 +1,14 @@
 apiVersion: skaffold/v4beta11
 kind: Config
 metadata:
-  name: kana-site
+  name: kotoba-lab
 
 build:
   artifacts:
-    - image: kana-client
+    - image: kotoba-client
       docker:
         dockerfile: docker/Dockerfile.client
-    - image: kana-server
+    - image: kotoba-server
       docker:
         dockerfile: docker/Dockerfile.server
   local:
@@ -21,12 +21,12 @@ deploy:
 
 portForward:
   - resourceType: service
-    resourceName: kana-client
-    namespace: kana
+    resourceName: kotoba-client
+    namespace: kotoba
     port: 80
     localPort: 8080
   - resourceType: service
-    resourceName: kana-server
-    namespace: kana
+    resourceName: kotoba-server
+    namespace: kotoba
     port: 3001
     localPort: 3001


### PR DESCRIPTION
Closes https://github.com/shikarii/kotoba-lab/issues/1

## Summary

End-to-end pipeline for capturing Japanese sentences while browsing, enriching them with furigana + AI translation, and saving as flashcards — all running locally.

### Schema
- Added `translation_model`, `furigana_source`, `enriched_at` provenance columns to `cards` table (idempotent `ALTER TABLE` migrations)

### Server
- `POST /api/v1/sentences/enrich` — returns furigana (kuroshiro) + translation (Ollama `qwen2.5:3b`)
- `POST /api/v1/sentences/capture` — enriches + inserts card with FSRS scheduling row in one call
- `OLLAMA_URL` / `OLLAMA_MODEL` config via env (zod-validated)
- Type declaration shims for `kuroshiro` / `kuroshiro-analyzer-kuromoji` (no `@types/` packages exist)

### Local infrastructure
- **k3d + Helm (primary):** `scripts/setup-local.sh` bootstraps k3d cluster, nginx ingress, Ollama via Helm (`helm/ollama/values.yaml`), pulls `qwen2.5:3b`, builds + imports `kotoba-server:local` / `kotoba-client:local`, applies `k8s/` manifests, adds `kotoba.local` to `/etc/hosts`
- **Docker Compose (fallback):** `docker/docker-compose.prod.yml` adds Ollama service with NVIDIA GPU passthrough, persistent volume, healthcheck, and one-shot `--profile setup` model pull

### Browser extension
- **Tampermonkey v0** (`extension/tampermonkey/kotoba-capture.user.js`) — select Japanese text on any page → `+ Kana` button → overlay showing furigana + translation
- **Firefox WebExtension MV3** (`extension/`) — context menu → popup with furigana preview, deck picker, save via `/capture`

### Project rename
- Renamed from `kana-site` → `kotoba-lab` throughout: package names, k8s namespace/resources, Docker images, hostname (`kotoba.local`), Dagger cache volumes, IndexedDB name, extension IDs, docs

### CI
- Playwright popup smoke tests (11 tests) wired into Dagger `clientQuality` pipeline
- Renamed Dagger main object `KanaCi` → `KotobaLabCi` to match module name

## Test plan
- `npm run test:e2e` — 11 Playwright popup tests passing
- `npm run test` (server) — Vitest integration tests against in-memory SQLite
- Manual validation: `bash scripts/setup-local.sh` → install Tampermonkey script → select Japanese text → confirm furigana + translation overlay appears