### PR TITLE
feat: Kotoba Firefox extension v1 — icons, gecko ID, branding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ ehthumbs.db
 Icon?
 desktop.ini
 
+# Extension assets — explicitly track (Icon? above would block these otherwise)
+!extension/icons/
+
 # Misc
 *.log
 *.bak

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,6 +1,6 @@
 browser.contextMenus.create({
   id: 'kotoba-capture',
-  title: 'Add to Kana',
+  title: 'Add to Kotoba',
   contexts: ['selection'],
 });
 

--- a/extension/icons/icon.svg
+++ b/extension/icons/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="20" fill="#1e1c18"/>
+  <text
+    x="64" y="90"
+    font-size="80"
+    text-anchor="middle"
+    fill="#3a9570"
+    font-family="'Hiragino Sans', 'Noto Sans JP', 'Yu Gothic', sans-serif"
+  >言</text>
+</svg>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "name": "Kana Capture",
-  "version": "0.1.0",
+  "name": "Kotoba",
+  "version": "1.0.0",
   "description": "Select Japanese text on any page and save it as a flashcard in kotoba-lab.",
   "permissions": ["contextMenus", "storage", "activeTab"],
   "host_permissions": [
@@ -13,10 +13,17 @@
   },
   "action": {
     "default_popup": "popup/popup.html",
-    "default_title": "Kana Capture"
+    "default_title": "Kotoba",
+    "default_icon": "icons/icon.svg"
   },
   "icons": {
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
+    "48": "icons/icon.svg",
+    "128": "icons/icon.svg"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "kotoba@kotoba.local",
+      "strict_min_version": "109.0"
+    }
   }
 }

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Kana Capture</title>
+  <title>Kotoba</title>
   <link rel="stylesheet" href="popup.css" />
 </head>
 <body>
   <div id="app">
     <header>
-      <span class="logo">Kana Capture</span>
+      <span class="logo">Kotoba</span>
     </header>
 
     <section id="loading" class="state">

--- a/extension/tampermonkey/kotoba-capture.user.js
+++ b/extension/tampermonkey/kotoba-capture.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
-// @name         Kana Capture
+// @name         Kotoba Capture
 // @namespace    http://kotoba.local/
-// @version      0.1.0
-// @description  Select Japanese text on any page → enrich with furigana + translation via kana-site
+// @version      1.0.0
+// @description  Select Japanese text on any page → enrich with furigana + translation via kotoba-lab
 // @author       shikarii
 // @match        *://*/*
 // @grant        GM_xmlhttpRequest


### PR DESCRIPTION
Closes https://github.com/shikarii/kotoba-lab/issues/2

## Summary

- **`extension/icons/icon.svg`** — 言 glyph on dark background using the app's palette (`#1e1c18` bg, `#3a9570` accent). Firefox supports SVG natively for extension icons.
- **`manifest.json`** — renamed to "Kotoba", bumped to v1.0.0, SVG icons wired in, added `browser_specific_settings.gecko` block (`id: kotoba@kotoba.local`, min Firefox 109) required for `about:debugging` loads and future AMO signing
- **`background.js`** — context menu entry renamed "Add to Kotoba"
- **`popup.html`** — `<title>` and header logo updated to "Kotoba"
- **`tampermonkey/kana-capture.user.js` → `kotoba-capture.user.js`** — file renamed, `@name`, `@description`, `@version` updated
- **`.gitignore`** — added `!extension/icons/` exception (`Icon?` OS pattern was blocking the directory)

## Install (temporary, no signing needed)
1. `about:debugging` → This Firefox → Load Temporary Add-on
2. Select `extension/manifest.json`
3. Select Japanese text on any page → right-click → **Add to Kotoba**

Tampermonkey script (`extension/tampermonkey/kotoba-capture.user.js`) remains available as the no-install alternative.

## Test plan
- `npm run test:e2e` — 11 Playwright popup tests passing
- Manual validation: load extension in Firefox via about:debugging, select Japanese text, confirm popup opens with furigana + deck picker