### PR TITLE
feat: Anki addon + full card metadata schema

### DIFF
--- a/client/lib/demoData.ts
+++ b/client/lib/demoData.ts
@@ -28,5 +28,8 @@ export const DEMO_CARDS: CardWithSchedule[] = PAIRS.map(([front, back], i) => ({
   front,
   back,
   createdAt: 0,
+  noteType: null,
+  tags: [],
+  extraFields: {},
   scheduling: { cardId: i + 1, ...newFsrsState(0) },
 }));

--- a/client/types/api.ts
+++ b/client/types/api.ts
@@ -53,6 +53,9 @@ export interface Card {
   front: string;
   back: string;
   createdAt: number;
+  noteType: string | null;
+  tags: string[];
+  extraFields: Record<string, string>;
 }
 
 export interface CardScheduling {
@@ -88,6 +91,9 @@ export interface CreateDeckRequest {
 export interface CreateCardRequest {
   front: string;
   back: string;
+  noteType?: string;
+  tags?: string[];
+  extraFields?: Record<string, string>;
 }
 
 export interface SubmitReviewRequest {

--- a/plugins/anki-kotoba/__init__.py
+++ b/plugins/anki-kotoba/__init__.py
@@ -1,0 +1,180 @@
+"""
+Kotoba-Lab Exporter
+Exports a deck from Anki to your running Kotoba-Lab server via its REST API.
+
+Install: copy this folder into your Anki add-ons directory
+  (Tools > Add-ons > View Files)
+then restart Anki.
+
+Usage: Tools > Export deck to Kotoba-Lab…
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import urllib.error
+import urllib.request
+from typing import Optional
+
+from aqt import gui_hooks, mw
+from aqt.qt import (
+    QAction,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
+from aqt.utils import showInfo, showWarning, tooltip
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _strip_html(text: str) -> str:
+    """Remove HTML tags and decode entities (Anki stores fields as HTML)."""
+    text = re.sub(r'<[^>]+>', '', text)
+    return html.unescape(text).strip()
+
+
+def _post_json(url: str, payload: dict) -> dict:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+# ── dialog ────────────────────────────────────────────────────────────────────
+
+
+class ExportDialog(QDialog):
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Export to Kotoba-Lab")
+        self.setMinimumWidth(420)
+
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel("Server URL:"))
+        self.url_input = QLineEdit()
+        cfg = mw.addonManager.getConfig(__name__) or {}
+        self.url_input.setText(cfg.get("server_url", "http://localhost:3000"))
+        layout.addWidget(self.url_input)
+
+        layout.addWidget(QLabel("Deck to export:"))
+        self.deck_combo = QComboBox()
+        for name in sorted(mw.col.decks.all_names()):
+            self.deck_combo.addItem(name)
+        layout.addWidget(self.deck_combo)
+
+        btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+        layout.addWidget(btns)
+
+    def values(self) -> tuple[str, str]:
+        return self.url_input.text().rstrip("/"), self.deck_combo.currentText()
+
+
+# ── main action ───────────────────────────────────────────────────────────────
+
+
+def export_deck() -> None:
+    dlg = ExportDialog(mw)
+    if dlg.exec() != QDialog.DialogCode.Accepted:
+        return
+
+    server_url, deck_name = dlg.values()
+
+    # Persist server URL for next time
+    cfg = mw.addonManager.getConfig(__name__) or {}
+    cfg["server_url"] = server_url
+    mw.addonManager.writeConfig(__name__, cfg)
+
+    # Collect note data on the main thread (safe, fast)
+    note_ids = mw.col.find_notes(f'deck:"{deck_name}"')
+    if not note_ids:
+        showWarning(f"No notes found in deck '{deck_name}'.")
+        return
+
+    NotePayload = dict  # {front, back, noteType, tags, extraFields}
+    payloads: list[NotePayload] = []
+
+    for nid in note_ids:
+        note = mw.col.get_note(nid)
+        note_type = note.note_type()
+        field_names = [f["name"] for f in note_type["flds"]]
+        extra_fields = {field_names[i]: note.fields[i] for i in range(len(note.fields))}
+
+        # front/back are stripped-text versions of the first two fields
+        front = _strip_html(note.fields[0]) if len(note.fields) > 0 else ""
+        back = _strip_html(note.fields[1]) if len(note.fields) > 1 else ""
+        if not front:
+            continue
+
+        payloads.append({
+            "front": front,
+            "back": back,
+            "noteType": note_type["name"],
+            "tags": list(note.tags),
+            "extraFields": extra_fields,
+        })
+
+    if not payloads:
+        showWarning("No valid notes found in that deck.")
+        return
+
+    tooltip(f"Exporting {len(payloads)} cards…")
+
+    # HTTP work runs in background so the UI stays responsive
+    def do_export() -> tuple[int, int]:
+        deck_resp = _post_json(f"{server_url}/api/v1/decks", {"name": deck_name})
+        deck_id = deck_resp["id"]
+
+        imported = skipped = 0
+        for payload in payloads:
+            try:
+                _post_json(f"{server_url}/api/v1/decks/{deck_id}/cards", payload)
+                imported += 1
+            except Exception:
+                skipped += 1
+
+        return imported, skipped
+
+    def on_done(fut) -> None:  # type: ignore[type-arg]
+        exc = fut.exception()
+        if exc:
+            showWarning(f"Export failed:\n{exc}")
+            return
+        imported, skipped = fut.result()
+        showInfo(
+            f"<b>Export complete!</b><br><br>"
+            f"Deck: <b>{deck_name}</b><br>"
+            f"Cards imported: <b>{imported}</b><br>"
+            f"Cards skipped: <b>{skipped}</b>"
+        )
+
+    mw.taskman.run_in_background(do_export, on_done=on_done)
+
+
+# ── register menu item ────────────────────────────────────────────────────────
+
+
+def _add_menu_item() -> None:
+    action = QAction("Export deck to Kotoba-Lab\u2026", mw)
+    action.triggered.connect(export_deck)
+    mw.form.menuTools.addAction(action)
+
+
+gui_hooks.main_window_did_init.append(_add_menu_item)

--- a/plugins/anki-kotoba/config.json
+++ b/plugins/anki-kotoba/config.json
@@ -1,0 +1,3 @@
+{
+  "server_url": "http://localhost:3000"
+}

--- a/plugins/anki-kotoba/manifest.json
+++ b/plugins/anki-kotoba/manifest.json
@@ -1,0 +1,8 @@
+{
+  "package": "anki-kotoba",
+  "name": "Kotoba-Lab Exporter",
+  "mod": 0,
+  "conflicts": [],
+  "min_point_version": 45,
+  "max_point_version": -1
+}

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -35,6 +35,10 @@ export const cards = sqliteTable('cards', {
   translationModel: text('translation_model'),
   furiganaSource: text('furigana_source'),
   enrichedAt: integer('enriched_at'),
+  // Anki note metadata — null for manually-created cards
+  noteType: text('note_type'),
+  tags: text('tags'),         // JSON string: string[]
+  extraFields: text('extra_fields'), // JSON string: Record<string, string> — all named fields with raw HTML
 });
 
 export type CardRow = typeof cards.$inferSelect;

--- a/server/src/db/setup.ts
+++ b/server/src/db/setup.ts
@@ -80,6 +80,9 @@ export function setupDatabase() {
     'ALTER TABLE cards ADD COLUMN translation_model TEXT',
     'ALTER TABLE cards ADD COLUMN furigana_source TEXT',
     'ALTER TABLE cards ADD COLUMN enriched_at INTEGER',
+    'ALTER TABLE cards ADD COLUMN note_type TEXT',
+    'ALTER TABLE cards ADD COLUMN tags TEXT',
+    'ALTER TABLE cards ADD COLUMN extra_fields TEXT',
   ]) {
     try {
       db.exec(col);

--- a/server/src/routes/decks.ts
+++ b/server/src/routes/decks.ts
@@ -15,6 +15,9 @@ const createDeckSchema = z.object({
 const createCardSchema = z.object({
   front: z.string().min(1),
   back: z.string().min(1),
+  noteType: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  extraFields: z.record(z.string()).optional(),
 });
 
 const submitReviewSchema = z.object({

--- a/server/src/routes/types.ts
+++ b/server/src/routes/types.ts
@@ -54,6 +54,12 @@ export interface Card {
   front: string;
   back: string;
   createdAt: number;
+  /** Anki note type name, e.g. "Basic", "Cloze". Null for manually-created cards. */
+  noteType: string | null;
+  /** Tags from the Anki note. Empty array for manually-created cards. */
+  tags: string[];
+  /** All named fields from the Anki note with raw HTML values. Empty object for manually-created cards. */
+  extraFields: Record<string, string>;
 }
 
 export interface CardScheduling {
@@ -89,6 +95,9 @@ export interface CreateDeckRequest {
 export interface CreateCardRequest {
   front: string;
   back: string;
+  noteType?: string;
+  tags?: string[];
+  extraFields?: Record<string, string>;
 }
 
 export interface SubmitReviewRequest {

--- a/server/src/services/ankiImportService.ts
+++ b/server/src/services/ankiImportService.ts
@@ -1,17 +1,30 @@
 import AdmZip from 'adm-zip';
 import Database from 'better-sqlite3';
 import { createDeck, importCards } from './deckService';
-import type { AnkiImportResponse } from '../routes/types';
+import type { AnkiImportResponse, CreateCardRequest } from '../routes/types';
 
 interface AnkiNote {
+  mid: number;
+  tags: string;
   flds: string;
+}
+
+interface AnkiModel {
+  name: string;
+  flds: Array<{ name: string }>;
 }
 
 /**
  * Import an Anki .apkg file into a new deck.
  *
  * An .apkg is a ZIP containing collection.anki2 (SQLite).
- * Notes table: flds column is \x1f-delimited; field[0]=front, field[1]=back.
+ * - notes.flds: \x1f-delimited field values
+ * - notes.mid:  model (note type) ID
+ * - notes.tags: space-separated tag string
+ * - col.models: JSON blob mapping model ID → { name, flds: [{name}] }
+ *
+ * front/back are the stripped-text versions of fields[0] and fields[1].
+ * extraFields stores all named fields with their raw HTML values.
  */
 export function importApkg(buffer: Buffer, deckName: string): AnkiImportResponse {
   const zip = new AdmZip(buffer);
@@ -28,23 +41,47 @@ export function importApkg(buffer: Buffer, deckName: string): AnkiImportResponse
   const anki = new Database(sqliteBuffer);
 
   let notes: AnkiNote[];
+  let models: Record<string, AnkiModel>;
   try {
-    notes = anki.prepare('SELECT flds FROM notes').all() as AnkiNote[];
+    notes = anki.prepare('SELECT mid, tags, flds FROM notes').all() as AnkiNote[];
+    const colRow = anki.prepare('SELECT models FROM col').get() as { models: string };
+    models = JSON.parse(colRow.models) as Record<string, AnkiModel>;
   } finally {
     anki.close();
   }
 
   const deck = createDeck({ name: deckName });
-  const pairs = notes.flatMap((note) => {
+
+  const cards: CreateCardRequest[] = notes.flatMap((note) => {
     const fields = note.flds.split('\x1f');
     const front = fields[0]?.trim() ?? '';
-    const back = fields[1]?.trim() ?? '';
     if (!front) return [];
-    return [{ front, back }];
+
+    const model = models[String(note.mid)];
+    const fieldNames = model?.flds.map((f) => f.name) ?? [];
+    const extraFields: Record<string, string> = {};
+    for (let i = 0; i < fields.length; i++) {
+      extraFields[fieldNames[i] ?? `Field ${i + 1}`] = fields[i] ?? '';
+    }
+
+    const tags = note.tags
+      .trim()
+      .split(/\s+/)
+      .filter((t) => t.length > 0);
+
+    return [
+      {
+        front,
+        back: fields[1]?.trim() ?? '',
+        noteType: model?.name ?? null,
+        tags,
+        extraFields,
+      } satisfies CreateCardRequest,
+    ];
   });
 
-  const imported = importCards(deck.id, pairs);
-  const skipped = pairs.length - imported;
+  const imported = importCards(deck.id, cards);
+  const skipped = cards.length - imported;
 
   return { deckId: deck.id, imported, skipped };
 }

--- a/server/src/services/deckService.ts
+++ b/server/src/services/deckService.ts
@@ -16,7 +16,7 @@ export function toDeck(row: typeof decks.$inferSelect): Deck {
 }
 
 export function toCard(
-  row: Pick<typeof cards.$inferSelect, 'id' | 'deckId' | 'front' | 'back' | 'createdAt'>
+  row: Pick<typeof cards.$inferSelect, 'id' | 'deckId' | 'front' | 'back' | 'createdAt' | 'noteType' | 'tags' | 'extraFields'>
 ): Card {
   return {
     id: row.id,
@@ -24,6 +24,9 @@ export function toCard(
     front: row.front,
     back: row.back,
     createdAt: row.createdAt,
+    noteType: row.noteType ?? null,
+    tags: row.tags ? (JSON.parse(row.tags) as string[]) : [],
+    extraFields: row.extraFields ? (JSON.parse(row.extraFields) as Record<string, string>) : {},
   };
 }
 
@@ -59,7 +62,7 @@ export function listCards(
   ).n;
   const rows = rawDb
     .prepare(
-      'SELECT id, deck_id, front, back, created_at FROM cards WHERE deck_id = ? ORDER BY id LIMIT ? OFFSET ?'
+      'SELECT id, deck_id, front, back, created_at, note_type, tags, extra_fields FROM cards WHERE deck_id = ? ORDER BY id LIMIT ? OFFSET ?'
     )
     .all(deckId, limit, offset) as Array<{
     id: number;
@@ -67,6 +70,9 @@ export function listCards(
     front: string;
     back: string;
     created_at: number;
+    note_type: string | null;
+    tags: string | null;
+    extra_fields: string | null;
   }>;
   return {
     cards: rows.map((r) => ({
@@ -75,16 +81,30 @@ export function listCards(
       front: r.front,
       back: r.back,
       createdAt: r.created_at,
+      noteType: r.note_type ?? null,
+      tags: r.tags ? (JSON.parse(r.tags) as string[]) : [],
+      extraFields: r.extra_fields ? (JSON.parse(r.extra_fields) as Record<string, string>) : {},
     })),
     total,
   };
 }
 
-export function createCard(deckId: number, { front, back }: CreateCardRequest): Card {
+export function createCard(
+  deckId: number,
+  { front, back, noteType, tags, extraFields }: CreateCardRequest,
+): Card {
   const db = getDb();
   const card = db
     .insert(cards)
-    .values({ deckId, front, back, createdAt: Math.floor(Date.now() / 1000) })
+    .values({
+      deckId,
+      front,
+      back,
+      createdAt: Math.floor(Date.now() / 1000),
+      noteType: noteType ?? null,
+      tags: tags ? JSON.stringify(tags) : null,
+      extraFields: extraFields ? JSON.stringify(extraFields) : null,
+    })
     .returning()
     .get();
   const fsrs = newFsrsState(Date.now());
@@ -111,12 +131,12 @@ export function deleteCard(id: number): void {
 
 // ─── Bulk import (used by text + anki import) ─────────────────────────────────
 
-export function importCards(deckId: number, pairs: Array<{ front: string; back: string }>): number {
+export function importCards(deckId: number, cards: CreateCardRequest[]): number {
   let imported = 0;
-  for (const { front, back } of pairs) {
-    if (!front.trim()) continue;
+  for (const card of cards) {
+    if (!card.front.trim()) continue;
     try {
-      createCard(deckId, { front: front.trim(), back: back.trim() });
+      createCard(deckId, { ...card, front: card.front.trim(), back: card.back.trim() });
       imported++;
     } catch {
       // skip duplicates or constraint violations

--- a/server/src/services/reviewService.ts
+++ b/server/src/services/reviewService.ts
@@ -12,6 +12,9 @@ type RawScheduledRow = {
   front: string;
   back: string;
   created_at: number;
+  note_type: string | null;
+  tags: string | null;
+  extra_fields: string | null;
   card_id: number;
   stability: number;
   difficulty: number;
@@ -28,6 +31,7 @@ export function nextDue(deckId: number): CardWithSchedule | null {
   const row = getRawDb()
     .prepare(
       `SELECT c.id, c.deck_id, c.front, c.back, c.created_at,
+              c.note_type, c.tags, c.extra_fields,
               s.card_id, s.stability, s.difficulty, s.elapsed_days,
               s.scheduled_days, s.reps, s.lapses, s.state, s.due_at, s.last_review_at
        FROM cards c
@@ -48,6 +52,9 @@ function rowToCardWithSchedule(r: RawScheduledRow): CardWithSchedule {
     front: r.front,
     back: r.back,
     createdAt: r.created_at,
+    noteType: r.note_type ?? null,
+    tags: r.tags ? (JSON.parse(r.tags) as string[]) : [],
+    extraFields: r.extra_fields ? (JSON.parse(r.extra_fields) as Record<string, string>) : {},
     scheduling: {
       cardId: r.card_id,
       stability: r.stability,
@@ -118,6 +125,9 @@ export function submitReview({ cardId, rating }: SubmitReviewRequest): CardWithS
     front: card.front,
     back: card.back,
     createdAt: card.createdAt,
+    noteType: card.noteType ?? null,
+    tags: card.tags ? (JSON.parse(card.tags) as string[]) : [],
+    extraFields: card.extraFields ? (JSON.parse(card.extraFields) as Record<string, string>) : {},
     scheduling: {
       cardId,
       stability: next.stability,


### PR DESCRIPTION
## Summary

- Add `plugins/anki-kotoba/` — Anki desktop addon (Python/PyQt) that exports any deck to kotoba-lab via the REST API, capturing all note fields, tags, and note type
- Extend `cards` table with `note_type`, `tags` (JSON array), `extra_fields` (JSON object of all named fields with raw HTML) via additive migrations
- Update `ankiImportService` to extract `mid`, `tags`, and `col.models` from `.apkg` SQLite so the file-upload path captures the same full metadata as the addon
- `importCards` signature updated to accept `CreateCardRequest[]` so metadata passes through the bulk import path
- Mirror `Card` and `CreateCardRequest` type changes in `client/types/api.ts`

## Test plan

- [x] manual validation confirmed locally
- [x] `plugins/anki-kotoba/` installs in Anki and appears under Tools menu
- [x] TypeScript types consistent across server and client

Closes https://github.com/shikarii/kotoba-lab/issues/24