### PR TITLE
feat: add API key authentication across all clients

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -1,6 +1,7 @@
-﻿import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import Home from './pages/Home';
+import Login from './pages/Login';
 import Romaji from './pages/Romaji';
 import Reader from './pages/Reader';
 import Decks from './pages/Decks';
@@ -9,16 +10,24 @@ import Browse from './pages/Browse';
 import DemoDecks from './pages/demo/DemoDecks';
 import DemoReview from './pages/demo/DemoReview';
 import DemoBrowse from './pages/demo/DemoBrowse';
+import { API_BASE, getApiKey } from './types/api';
+
+/** Redirect to /login when a real server is configured but no key is stored. */
+function RequireAuth({ children }: { children: React.ReactNode }) {
+  if (API_BASE && !getApiKey()) return <Navigate to="/login" replace />;
+  return <>{children}</>;
+}
 
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/romaji" element={<Romaji />} />
-      <Route path="/reader" element={<Reader />} />
-      <Route path="/decks" element={<Decks />} />
-      <Route path="/decks/:deckId/review" element={<Review />} />
-      <Route path="/decks/:deckId/browse" element={<Browse />} />
+      <Route path="/login" element={<Login />} />
+      <Route path="/" element={<RequireAuth><Home /></RequireAuth>} />
+      <Route path="/romaji" element={<RequireAuth><Romaji /></RequireAuth>} />
+      <Route path="/reader" element={<RequireAuth><Reader /></RequireAuth>} />
+      <Route path="/decks" element={<RequireAuth><Decks /></RequireAuth>} />
+      <Route path="/decks/:deckId/review" element={<RequireAuth><Review /></RequireAuth>} />
+      <Route path="/decks/:deckId/browse" element={<RequireAuth><Browse /></RequireAuth>} />
       <Route path="/demo/decks" element={<DemoDecks />} />
       <Route path="/demo/decks/:deckId/review" element={<DemoReview />} />
       <Route path="/demo/decks/:deckId/browse" element={<DemoBrowse />} />

--- a/client/components/Nav.tsx
+++ b/client/components/Nav.tsx
@@ -1,7 +1,17 @@
-﻿import React from 'react';
-import { NavLink } from 'react-router-dom';
+import React from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { API_BASE, clearApiKey, getApiKey } from '../types/api';
 
 export default function Nav() {
+  const navigate = useNavigate();
+
+  function handleLogout() {
+    clearApiKey();
+    navigate('/login');
+  }
+
+  const showLogout = !!API_BASE && !!getApiKey();
+
   return (
     <nav className="top-nav">
       <NavLink end className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')} to="/">
@@ -25,6 +35,11 @@ export default function Nav() {
       >
         Flashcards
       </NavLink>
+      {showLogout && (
+        <button className="nav-link nav-logout" onClick={handleLogout}>
+          Logout
+        </button>
+      )}
     </nav>
   );
 }

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { setApiKey } from '../types/api';
+import '../styles/login.css';
+
+export default function Login() {
+  const navigate = useNavigate();
+  const [key, setKey] = useState('');
+  const [error, setError] = useState('');
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = key.trim();
+    if (!trimmed) { setError('API key is required'); return; }
+    setApiKey(trimmed);
+    navigate('/');
+  }
+
+  return (
+    <main className="login-page">
+      <h1>Kotoba-Lab</h1>
+      <form className="login-form" onSubmit={handleSubmit}>
+        <label htmlFor="api-key">API Key</label>
+        <input
+          id="api-key"
+          type="password"
+          autoComplete="current-password"
+          placeholder="Enter your KOTOBA_API_KEY"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+        />
+        {error && <p className="login-error">{error}</p>}
+        <button className="btn-primary" type="submit">Connect</button>
+      </form>
+    </main>
+  );
+}

--- a/client/styles/login.css
+++ b/client/styles/login.css
@@ -1,0 +1,50 @@
+.login-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  gap: 2rem;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 360px;
+}
+
+.login-form label {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.login-form input {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid rgba(255 255 255 / 0.15);
+  border-radius: 6px;
+  background: rgba(255 255 255 / 0.05);
+  color: inherit;
+  font-size: 1rem;
+}
+
+.login-error {
+  color: #f87171;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.nav-logout {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: inherit;
+  padding: 0;
+  opacity: 0.6;
+}
+
+.nav-logout:hover {
+  opacity: 1;
+}

--- a/client/types/api.ts
+++ b/client/types/api.ts
@@ -109,12 +109,35 @@ export interface AnkiImportResponse {
 
 export const API_BASE = import.meta.env.VITE_API_URL ?? '';
 
+const API_KEY_STORAGE = 'kotoba_api_key';
+
+export function getApiKey(): string {
+  return localStorage.getItem(API_KEY_STORAGE) ?? '';
+}
+export function setApiKey(key: string): void {
+  localStorage.setItem(API_KEY_STORAGE, key);
+}
+export function clearApiKey(): void {
+  localStorage.removeItem(API_KEY_STORAGE);
+}
+
+function authHeaders(): Record<string, string> {
+  const key = getApiKey();
+  return key ? { Authorization: `Bearer ${key}` } : {};
+}
+
+function handleUnauthorized(): void {
+  clearApiKey();
+  window.location.hash = '#/login';
+}
+
 export async function apiImport(req: ImportRequest): Promise<ImportResponse> {
   const res = await fetch(`${API_BASE}/api/v1/sentences/import`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(req),
   });
+  if (res.status === 401) { handleUnauthorized(); throw new Error('Unauthorized'); }
   if (!res.ok) {
     const err = (await res.json().catch(() => ({ error: res.statusText }))) as ErrorResponse;
     throw new Error(err.error);
@@ -123,7 +146,11 @@ export async function apiImport(req: ImportRequest): Promise<ImportResponse> {
 }
 
 async function apiJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, init);
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...(init?.headers ?? {}), ...authHeaders() },
+  });
+  if (res.status === 401) { handleUnauthorized(); throw new Error('Unauthorized'); }
   if (!res.ok) {
     const err = (await res.json().catch(() => ({ error: res.statusText }))) as ErrorResponse;
     throw new Error(err.error);
@@ -146,7 +173,7 @@ export function apiCreateDeck(req: CreateDeckRequest): Promise<Deck> {
 }
 
 export function apiDeleteDeck(id: number): Promise<void> {
-  return fetch(`${API_BASE}/api/v1/decks/${id}`, { method: 'DELETE' }).then(() => undefined);
+  return fetch(`${API_BASE}/api/v1/decks/${id}`, { method: 'DELETE', headers: authHeaders() }).then(() => undefined);
 }
 
 export function apiListCards(
@@ -166,7 +193,7 @@ export function apiCreateCard(deckId: number, req: CreateCardRequest): Promise<C
 }
 
 export function apiDeleteCard(deckId: number, cardId: number): Promise<void> {
-  return fetch(`${API_BASE}/api/v1/decks/${deckId}/cards/${cardId}`, { method: 'DELETE' }).then(
+  return fetch(`${API_BASE}/api/v1/decks/${deckId}/cards/${cardId}`, { method: 'DELETE', headers: authHeaders() }).then(
     () => undefined
   );
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,6 +20,10 @@
     "48": "icons/icon.svg",
     "128": "icons/icon.svg"
   },
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": false
+  },
   "browser_specific_settings": {
     "gecko": {
       "id": "kotoba@kotoba.local",

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Kotoba Settings</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 1.5rem; max-width: 400px; }
+    label { display: block; margin-bottom: 0.25rem; font-size: 0.9rem; }
+    input { width: 100%; padding: 0.5rem; box-sizing: border-box; margin-bottom: 1rem; font-size: 1rem; }
+    button { padding: 0.5rem 1rem; font-size: 1rem; cursor: pointer; }
+    #status { margin-top: 0.75rem; font-size: 0.85rem; color: green; }
+  </style>
+</head>
+<body>
+  <h2>Kotoba Settings</h2>
+  <label for="api-key">API Key</label>
+  <input id="api-key" type="password" placeholder="Your KOTOBA_API_KEY" />
+  <button id="save-btn">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -1,0 +1,13 @@
+const input = document.getElementById('api-key');
+const status = document.getElementById('status');
+
+browser.storage.sync.get('kotoba_api_key').then(({ kotoba_api_key }) => {
+  if (kotoba_api_key) input.value = kotoba_api_key;
+});
+
+document.getElementById('save-btn').onclick = async () => {
+  const key = input.value.trim();
+  await browser.storage.sync.set({ kotoba_api_key: key });
+  status.textContent = key ? 'Saved.' : 'Cleared.';
+  setTimeout(() => { status.textContent = ''; }, 2000);
+};

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,5 +1,14 @@
 const API_BASES = ['http://kotoba.local', 'http://localhost:3001'];
 
+async function getApiKey() {
+  const { kotoba_api_key } = await browser.storage.sync.get('kotoba_api_key');
+  return kotoba_api_key ?? '';
+}
+
+function authHeaders(apiKey) {
+  return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+}
+
 async function apiBase() {
   for (const base of API_BASES) {
     try {
@@ -11,8 +20,8 @@ async function apiBase() {
 }
 
 function show(id) {
-  ['loading', 'result', 'done', 'error'].forEach((s) => {
-    document.getElementById(s).classList.toggle('hidden', s !== id);
+  ['loading', 'result', 'done', 'error', 'settings'].forEach((s) => {
+    document.getElementById(s)?.classList.toggle('hidden', s !== id);
   });
 }
 
@@ -21,14 +30,17 @@ function setError(msg) {
   show('error');
 }
 
-async function loadDecks(base) {
-  const res = await fetch(`${base}/api/v1/decks`);
+async function loadDecks(base, apiKey) {
+  const res = await fetch(`${base}/api/v1/decks`, { headers: authHeaders(apiKey) });
+  if (res.status === 401) throw new Error('Invalid API key — update it in settings.');
   if (!res.ok) throw new Error('Failed to load decks');
   return res.json();
 }
 
 async function main() {
   show('loading');
+
+  const apiKey = await getApiKey();
 
   const { pendingText } = await browser.storage.session.get('pendingText');
   if (!pendingText) { setError('No text captured. Select text then right-click → Add to Kana.'); return; }
@@ -40,9 +52,10 @@ async function main() {
   try {
     const res = await fetch(`${base}/api/v1/sentences/enrich`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders(apiKey) },
       body: JSON.stringify({ text: pendingText }),
     });
+    if (res.status === 401) { setError('Invalid API key — update it in extension settings.'); return; }
     if (!res.ok) throw new Error(`Enrich failed: ${res.status}`);
     enrichData = await res.json();
   } catch (e) { setError(e.message); return; }
@@ -54,7 +67,7 @@ async function main() {
     `${enrichData.furiganaSource} · ${enrichData.translationModel}`;
 
   let decks;
-  try { decks = await loadDecks(base); } catch { decks = []; }
+  try { decks = await loadDecks(base, apiKey); } catch (e) { setError(e.message); return; }
 
   const sel = document.getElementById('deck-select');
   sel.innerHTML = '';
@@ -80,7 +93,7 @@ async function main() {
     try {
       const res = await fetch(`${base}/api/v1/sentences/capture`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders(apiKey) },
         body: JSON.stringify({ text: pendingText, deckId }),
       });
       if (!res.ok) throw new Error(`Save failed: ${res.status}`);

--- a/extension/tests/popup.spec.ts
+++ b/extension/tests/popup.spec.ts
@@ -179,6 +179,9 @@ test('shows error when no pending text is set', async ({ page }) => {
   await page.addInitScript(() => {
     (window as unknown as Record<string, unknown>)['browser'] = {
       storage: {
+        sync: {
+          get: (_key: string) => Promise.resolve({ kotoba_api_key: '' }),
+        },
         session: {
           get: () => Promise.resolve({}),
           remove: () => Promise.resolve(),

--- a/extension/tests/popup.spec.ts
+++ b/extension/tests/popup.spec.ts
@@ -39,6 +39,9 @@ test.beforeEach(async ({ page }) => {
   await page.addInitScript((text: string) => {
     (window as unknown as Record<string, unknown>)['browser'] = {
       storage: {
+        sync: {
+          get: (_key: string) => Promise.resolve({ kotoba_api_key: '' }),
+        },
         session: {
           get: (_key: string) => Promise.resolve({ pendingText: text }),
           remove: (_key: string) => Promise.resolve(),

--- a/plugins/anki-kotoba/__init__.py
+++ b/plugins/anki-kotoba/__init__.py
@@ -41,14 +41,12 @@ def _strip_html(text: str) -> str:
     return html.unescape(text).strip()
 
 
-def _post_json(url: str, payload: dict) -> dict:
+def _post_json(url: str, payload: dict, api_key: str = "") -> dict:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     data = json.dumps(payload).encode()
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     with urllib.request.urlopen(req, timeout=15) as resp:
         return json.loads(resp.read())
 
@@ -70,6 +68,12 @@ class ExportDialog(QDialog):
         self.url_input.setText(cfg.get("server_url", "http://localhost:3000"))
         layout.addWidget(self.url_input)
 
+        layout.addWidget(QLabel("API Key (leave blank if auth is disabled):"))
+        self.key_input = QLineEdit()
+        self.key_input.setEchoMode(QLineEdit.EchoMode.Password)
+        self.key_input.setText(cfg.get("api_key", ""))
+        layout.addWidget(self.key_input)
+
         layout.addWidget(QLabel("Deck to export:"))
         self.deck_combo = QComboBox()
         for name in sorted(mw.col.decks.all_names()):
@@ -83,8 +87,8 @@ class ExportDialog(QDialog):
         btns.rejected.connect(self.reject)
         layout.addWidget(btns)
 
-    def values(self) -> tuple[str, str]:
-        return self.url_input.text().rstrip("/"), self.deck_combo.currentText()
+    def values(self) -> tuple[str, str, str]:
+        return self.url_input.text().rstrip("/"), self.key_input.text().strip(), self.deck_combo.currentText()
 
 
 # ── main action ───────────────────────────────────────────────────────────────
@@ -95,11 +99,12 @@ def export_deck() -> None:
     if dlg.exec() != QDialog.DialogCode.Accepted:
         return
 
-    server_url, deck_name = dlg.values()
+    server_url, api_key, deck_name = dlg.values()
 
-    # Persist server URL for next time
+    # Persist server URL and api_key for next time
     cfg = mw.addonManager.getConfig(__name__) or {}
     cfg["server_url"] = server_url
+    cfg["api_key"] = api_key
     mw.addonManager.writeConfig(__name__, cfg)
 
     # Collect note data on the main thread (safe, fast)
@@ -139,13 +144,13 @@ def export_deck() -> None:
 
     # HTTP work runs in background so the UI stays responsive
     def do_export() -> tuple[int, int]:
-        deck_resp = _post_json(f"{server_url}/api/v1/decks", {"name": deck_name})
+        deck_resp = _post_json(f"{server_url}/api/v1/decks", {"name": deck_name}, api_key)
         deck_id = deck_resp["id"]
 
         imported = skipped = 0
         for payload in payloads:
             try:
-                _post_json(f"{server_url}/api/v1/decks/{deck_id}/cards", payload)
+                _post_json(f"{server_url}/api/v1/decks/{deck_id}/cards", payload, api_key)
                 imported += 1
             except Exception:
                 skipped += 1

--- a/plugins/anki-kotoba/config.json
+++ b/plugins/anki-kotoba/config.json
@@ -1,3 +1,4 @@
 {
-  "server_url": "http://localhost:3000"
+  "server_url": "http://localhost:3000",
+  "api_key": ""
 }

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -6,6 +6,8 @@ const EnvSchema = z.object({
   CORS_ORIGIN: z.string().default('http://localhost:5173'),
   OLLAMA_URL: z.string().default('http://ollama:11434'),
   OLLAMA_MODEL: z.string().default('qwen2.5:3b'),
+  /** If set, all /api/v1/* requests must supply Authorization: Bearer <key>. */
+  KOTOBA_API_KEY: z.string().optional(),
 });
 
 export type Config = z.infer<typeof EnvSchema>;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -15,6 +15,17 @@ app.use('*', honoLogger());
 
 app.get('/health', (c) => c.json({ ok: true }));
 
+// Auth middleware — only enforced when KOTOBA_API_KEY is set
+app.use('/api/v1/*', async (c, next) => {
+  const requiredKey = config.KOTOBA_API_KEY;
+  if (!requiredKey) return next();
+  const auth = c.req.header('Authorization');
+  if (auth !== `Bearer ${requiredKey}`) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+  return next();
+});
+
 app.route('/api/v1/sentences', sentenceRoutes);
 app.route('/api/v1/sentences', enrichRoutes);
 app.route('/api/v1/decks', deckRoutes);


### PR DESCRIPTION
## Summary

- **Server**: optional `KOTOBA_API_KEY` env var; Hono middleware on all `/api/v1/*` routes enforces `Authorization: Bearer <key>` when set (dev mode works without it)
- **Client**: `Login` page + `RequireAuth` guard redirects to `/login` when `VITE_API_URL` is set but no key stored; `authHeaders()` helper wired into all fetch calls; logout button in `Nav`
- **Anki addon**: `api_key` field added to config/dialog, sent as `Bearer` token on export
- **Firefox extension**: new options page (`extension/options/`) lets users save the API key to `browser.storage.sync`; popup reads it and sends it on every request; `manifest.json` registers `options_ui`

Closes https://github.com/shikarii/kotoba-lab/issues/27

## Test plan

- [ ] Start server without `KOTOBA_API_KEY` — all API routes accessible without auth (dev default)
- [ ] Set `KOTOBA_API_KEY=secret` in server env; confirm unauthenticated requests return 401
- [ ] Open client with `VITE_API_URL` set — redirects to `/login`; enter key → gains access → logout clears key and redirects back
- [ ] Demo routes (`/#/demo/decks`, etc.) remain accessible without login
- [ ] Anki addon: enter key in export dialog → export succeeds against authenticated server
- [ ] Firefox extension: open addon options, save key, open popup → flashcard save succeeds

## Validation

Manual validation performed locally: `npm run typecheck` passes, login/logout flow works, unauthenticated requests return 401 when key is set.